### PR TITLE
Fix string_clear_get_str when stack allocated

### DIFF
--- a/m-string.h
+++ b/m-string.h
@@ -189,6 +189,7 @@ string_clear_get_str(string_t v)
   char *p = v->ptr;
   if (stringi_stack_p(v)) {
     // The string was stack allocated.
+    p = v->u.stack.buffer;
     // Need to allocate a heap string to return the copy.
     size_t alloc = string_size(v)+1;
     char *ptr = M_MEMORY_REALLOC (char, NULL, alloc);

--- a/tests/test-mstring.c
+++ b/tests/test-mstring.c
@@ -355,6 +355,13 @@ static void test0(void)
   char *s = string_clear_get_str (s1);
   assert(strcmp(s, "QWERTYQWERTY") == 0);
   free(s);
+
+  string_t s3;
+  string_init(s3);
+  string_cat_str(s3, "ABC");
+  s = string_clear_get_str(s3);
+  assert(strcmp(s, "ABC") == 0);
+  free(s);
   
   string_init_set_str(s1, "RESTART");
   assert (string_equal_str_p(s1, "RESTART"));


### PR DESCRIPTION
If a string_t is stack-allocated, string_clear_get_str would still try
to copy it from the NULL heap pointer, resulting in a failed assertion.
Copy from the stack instead. Also add a test for this.