### PR TITLE
docs: Fix a few typos

### DIFF
--- a/example/ex-algo03.c
+++ b/example/ex-algo03.c
@@ -3,7 +3,7 @@
 #include "m-algo.h"
 #include "m-string.h"
 
-/* Define a dictionnary (or hash_map or undordered_map)
+/* Define a dictionnary (or hash_map or unordered_map)
  * from a string_t to int */
 DICT_DEF2(dict, string_t, int)
 /* Register the oplist of this dictionnary globally */

--- a/m-algo.h
+++ b/m-algo.h
@@ -505,7 +505,7 @@
  */
 #define M_ALG0_FIND_DEF_P5(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
   /* It supposes that the container is not sorted */                          \
-  /* Find the next occurence from it (included) of data */                    \
+  /* Find the next occurrence from it (included) of data */                    \
   static inline void                                                          \
   M_C(name, _find_again) (it_t it, type_t const data)                         \
   {                                                                           \
@@ -516,7 +516,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  /* Find the first occurence of data */                                      \
+  /* Find the first occurrence of data */                                      \
   static inline void                                                          \
   M_C(name, _find) (it_t it, container_t const l, type_t const data)          \
   {                                                                           \
@@ -533,7 +533,7 @@
     return !M_CALL_IT_END_P(cont_oplist, it);                                 \
   }                                                                           \
                                                                               \
-  /* Find the last occurence of data in the container */                      \
+  /* Find the last occurrence of data in the container */                      \
   /* For the definition of _find_last, if the methods                         \
      PREVIOUS & IT_LAST are defined, then search backwards */                 \
   M_IF_METHOD2(PREVIOUS, IT_LAST, cont_oplist)                                \
@@ -550,7 +550,7 @@
      }                                                                        \
    }                                                                          \
    ,                                                                          \
-   /* Otherwise search forward, but don't stop on the first occurence */      \
+   /* Otherwise search forward, but don't stop on the first occurrence */      \
    static inline void                                                         \
    M_C(name, _find_last) (it_t it, container_t const l, type_t const data)    \
    {                                                                          \
@@ -566,7 +566,7 @@
    }                                                                          \
    ) /* End of alternative of _find_last */                                   \
                                                                               \
-  /* Count the number of occurence of data in the container */                \
+  /* Count the number of occurrence of data in the container */                \
   static inline size_t                                                        \
   M_C(name, _count) (container_t const l, type_t const data)                  \
   {                                                                           \
@@ -613,7 +613,7 @@
  */
 #define M_ALG0_FIND_IF_DEF_P5(name, container_t, cont_oplist, type_t, type_oplist, it_t, suffix, test_t, eq_t, call_test, call_eq) \
                                                                               \
-  /* Find the next occurence that matches the condition */                    \
+  /* Find the next occurrence that matches the condition */                    \
   static inline void                                                          \
   M_C3(name, _find_again_, suffix) (it_t it, test_t func)                     \
   {                                                                           \
@@ -624,7 +624,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  /* Find the first occurence that matches the condition */                   \
+  /* Find the first occurrence that matches the condition */                   \
   static inline void                                                          \
   M_C3(name, _find_, suffix) (it_t it, container_t l, test_t func)            \
   {                                                                           \
@@ -632,7 +632,7 @@
     M_C3(name, _find_again_, suffix)(it, func);                               \
   }                                                                           \
                                                                               \
-  /* Count the number of occurence that matches the condition */              \
+  /* Count the number of occurrence that matches the condition */              \
   static inline size_t                                                        \
   M_C3(name, _count_, suffix) (container_t const l, test_t func)              \
   {                                                                           \
@@ -685,7 +685,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  /* Fill the container with exactly 'n' occurence of 'value' */              \
+  /* Fill the container with exactly 'n' occurrence of 'value' */              \
   M_IF_METHOD(PUSH, cont_oplist)(                                             \
   static inline void                                                          \
   M_C(name, _fill_n) (container_t l, size_t n, type_t const value)            \

--- a/m-core.h
+++ b/m-core.h
@@ -34,7 +34,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-/* By default, always use stdio. Can be turned off in specific environement if needed
+/* By default, always use stdio. Can be turned off in specific environment if needed
    by defining M_USE_STDIO to 0 */
 #ifndef M_USE_STDIO
 # define M_USE_STDIO 1
@@ -43,7 +43,7 @@
 # include <stdio.h>
 #endif
 
-/* By default, always use stdarg. Can be turned off in specific environement if needed
+/* By default, always use stdarg. Can be turned off in specific environment if needed
    by defining M_USE_STDARG to 0 */
 #ifndef M_USE_STDARG
 # define M_USE_STDARG 1

--- a/m-dict.h
+++ b/m-dict.h
@@ -270,7 +270,7 @@
 
 
 
-/* Define the structure of a chained dictionnary for all kind of dictionnaries
+/* Define the structure of a chained dictionnary for all kind of dictionaries
  * name: prefix of the container,
  * key_type: type of the key
  * key_oplist: oplist of the key
@@ -450,7 +450,7 @@
   static inline void                                                          \
   M_C3(m_d1ct_,name,_resize_up)(dict_t map)                                   \
   {                                                                           \
-    /* NOTE: Contract may not be fullfilled here */                           \
+    /* NOTE: Contract may not be fulfilled here */                           \
     size_t old_size = M_C(name, _array_list_pair_size)(map->table);           \
     size_t new_size = old_size * 2;                                           \
     if (M_UNLIKELY (new_size <= old_size)) {                                  \
@@ -490,7 +490,7 @@
   static inline void                                                          \
   M_C3(m_d1ct_,name,_resize_down)(dict_t map)                                 \
   {                                                                           \
-    /* NOTE: Contract may not be fullfilled here */                           \
+    /* NOTE: Contract may not be fulfilled here */                           \
     size_t old_size = M_C(name, _array_list_pair_size)(map->table);           \
     M_ASSERT ((old_size % 2) == 0);                                           \
     size_t new_size = old_size / 2;                                           \
@@ -748,7 +748,7 @@
       return true;                                                            \
     /* Otherwise this is the slow path :                                      \
        both dictionary may not have arrays with the same size, but            \
-       still the dictionnaries shall be equal as they contain the same        \
+       still the dictionaries shall be equal as they contain the same        \
        items. */                                                              \
     dict_it_t it;                                                             \
     for(M_C(name, _it)(it, dict1) ;                                           \
@@ -1025,7 +1025,7 @@
   , /* NO UPDATE */) )                                                        \
                                                                               \
   /* HASH method for dictionnary itself seems hard to implement:              \
-     we have to handle the case where two dictionnaries are structuraly       \
+     we have to handle the case where two dictionaries are structuraly       \
      different, but functionnaly identical (seems they have the same          \
      members, but put in a different order).                                  \
      We cannot iterator over the dictionary to compute a hash, as the         \

--- a/m-string.h
+++ b/m-string.h
@@ -103,7 +103,7 @@ typedef enum string_fgets_e {
 static inline bool
 m_str1ng_stack_p(const string_t s)
 {
-  // Function can be called when contract is not fullfilled
+  // Function can be called when contract is not fulfilled
   return (s->ptr == NULL);
 }
 
@@ -111,7 +111,7 @@ m_str1ng_stack_p(const string_t s)
 static inline void
 m_str1ng_set_size(string_t s, size_t size)
 {
-  // Function can be called when contract is not fullfilled
+  // Function can be called when contract is not fulfilled
   if (m_str1ng_stack_p(s)) {
     M_ASSERT (size < sizeof (string_heap_ct) - 1);
     // The size of the string is stored as the last char of the buffer.
@@ -124,7 +124,7 @@ m_str1ng_set_size(string_t s, size_t size)
 static inline size_t
 string_size(const string_t s)
 {
-  // Function can be called when contract is not fullfilled
+  // Function can be called when contract is not fulfilled
   // Reading both values before calling the '?' operator allows compiler to generate branchless code
   const size_t s_stack = (size_t) s->u.stack.buffer[sizeof (string_heap_ct) - 1];
   const size_t s_heap  = s->u.heap.size;
@@ -135,7 +135,7 @@ string_size(const string_t s)
 static inline size_t
 string_capacity(const string_t s)
 {
-  // Function can be called when contract is not fullfilled
+  // Function can be called when contract is not fulfilled
   // Reading both values before calling the '?' operator allows compiler to generate branchless code
   const size_t c_stack = sizeof (string_heap_ct) - 1;
   const size_t c_heap  = s->u.heap.alloc;
@@ -146,7 +146,7 @@ string_capacity(const string_t s)
 static inline char*
 m_str1ng_get_cstr(string_t v)
 {
-  // Function can be called when contract is not fullfilled
+  // Function can be called when contract is not fulfilled
   char *const ptr_stack = &v->u.stack.buffer[0];
   char *const ptr_heap  = v->ptr;
   return m_str1ng_stack_p(v) ?  ptr_stack : ptr_heap;
@@ -156,7 +156,7 @@ m_str1ng_get_cstr(string_t v)
 static inline const char*
 string_get_cstr(const string_t v)
 {
-  // Function cannot be called when contract is not fullfilled
+  // Function cannot be called when contract is not fulfilled
   // but it is called by contract (so no contract check to avoid infinite recursion).
   const char *const ptr_stack = &v->u.stack.buffer[0];
   const char *const ptr_heap  = v->ptr;
@@ -267,7 +267,7 @@ m_str1ng_fit2size (string_t v, size_t size_alloc)
 {
   M_ASSERT_INDEX (0, size_alloc);
   // Note: this function may be called in context where the contract
-  // is not fullfilled.
+  // is not fulfilled.
   const size_t old_alloc = string_capacity(v);
   // This line enables the compiler to completly remove this function
   // for very short constant strings.
@@ -810,14 +810,14 @@ m_str1ng_replace_all_str_1ge2 (string_t v, const char str1[], size_t str1len, co
 
   // Go through all the characters of the string
   while (*src != 0) {
-    // Get a new occurence of str1 in the v string.
+    // Get a new occurrence of str1 in the v string.
     char *occ = strstr(src, str1);
     if (occ == NULL) {
-      // No new occurence
+      // No new occurrence
       break;
     }
     M_ASSERT(occ >= src);
-    // Copy the data until the new occurence
+    // Copy the data until the new occurrence
     if (src != dst) {
       memmove(dst, src, (size_t) (occ - src));
     }
@@ -885,7 +885,7 @@ m_str1ng_replace_all_str_1lo2 (string_t v, const char str1[], size_t str1len, co
       break;
     }
     M_ASSERT(occ + str1len - 1 <= src);
-    // Copy the data until the new occurence
+    // Copy the data until the new occurrence
     dst -= (src - (occ + str1len - 1));
     memmove(dst, occ+str1len, (size_t) (src - (occ + str1len - 1)));
     // Copy the replaced string


### PR DESCRIPTION
There are small typos in:
- example/ex-algo03.c
- m-algo.h
- m-core.h
- m-dict.h
- m-string.h

Fixes:
- Should read `occurrence` rather than `occurence`.
- Should read `fulfilled` rather than `fullfilled`.
- Should read `dictionaries` rather than `dictionnaries`.
- Should read `environment` rather than `environement`.
- Should read `unordered` rather than `undordered`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md