### PR TITLE
bitset: clear stale bits in reset/resize

### DIFF
--- a/m-bitset.h
+++ b/m-bitset.h
@@ -98,6 +98,10 @@ m_bitset_reset(m_bitset_t t)
 {
   M_B1TSET_CONTRACT(t);
   t->size = 0;
+  // to support calling resize after reset, clear the bits in the first limb
+  if (M_LIKELY(t->ptr != 0)) {
+    t->ptr[0] = 0;
+  }
 }
 
 /* Clear a bitset (DESTRUCTOR) */

--- a/tests/test-mbitset.c
+++ b/tests/test-mbitset.c
@@ -420,6 +420,19 @@ static void test_clz(void)
   }
 }
 
+static void test_reset_resize(void)
+{
+  M_LET(set, bitset_t) {
+    bitset_init(set);
+    bitset_resize(set, 128);
+    bitset_set_at(set, 0, true);
+    bitset_reset(set);
+    bitset_resize(set, 128);
+    assert(bitset_get(set, 0) == false);
+  }
+}
+
+
 int main(void)
 {
   test1();
@@ -428,5 +441,6 @@ int main(void)
   test_logic();
   test_let();
   test_clz();
+  test_reset_resize();
   exit(0);
 }


### PR DESCRIPTION
There's a gap in `mbitset_resize()` where the first limb of a grown
bitset is not initialized to zero.  This is most easily exposed when
using `mbitset_reset()` followed by `mbitset_resize()`:

```c
  M_LET(set, bitset_t) {
    bitset_init(set);
    bitset_resize(set, 128);
    bitset_set_at(set, 0, true);
    bitset_reset(set);
    bitset_resize(set, 128);
    assert(bitset_get(set, 0) == false);
  }
```

`mbitset_reset()` assumes the first limb has been zeroed either in
`realloc()` or by a previous `mbitset_resize()` call.  However,
`mbitset_reset()` reduces the size, but does not zero the first limb as
would be done by `mbitset_resize(set, 0)`.

In this commit, I have added the zeroing of the first limb to
`mbitset_reset()`.

NOTE: This fix does not resolve the issue if `realloc()` returns dirty
memory.  It could be done by calling `memset()` following the
allocation, but as the existing code avoids `memset()` I wasn't sure if
this was being intentionally avoided.