### PR TITLE
Add m_string_cat_vprintf

### DIFF
--- a/tests/test-mstring.c
+++ b/tests/test-mstring.c
@@ -143,6 +143,14 @@ static void test_utf8_it(void)
   string_clear(s);
 }
 
+static void call_string_cat_vprintf(string_t s, const char format[], ...)
+{
+  va_list args;
+  va_start (args, format);
+  string_cat_vprintf(s, format, args);
+  va_end (args);
+}
+
 static void test0(void)
 {
   string_t s1;
@@ -376,13 +384,25 @@ static void test0(void)
   string_set_str(s2, "Hello, world! 10 little suns.");
   assert(string_equal_p(s1, s2) == true);
 
+  string_set_str(s1, "Hello, world!");
+  call_string_cat_vprintf(s1, " %d little %s.", 10, "suns");
+  assert(string_equal_p(s1, s2) == true);
+
   string_set_str(s1, "X:");
   string_cat_printf(s1, "");
+  assert(string_equal_str_p(s1, "X:") == true);
+
+  string_set_str(s1, "X:");
+  call_string_cat_vprintf(s1, "");
   assert(string_equal_str_p(s1, "X:") == true);
 
   // Illegal format char
   string_set_str(s1, "X:");
   string_cat_printf(s1, "%#");
+  assert(string_equal_str_p(s1, "X:") == true);
+
+  string_set_str(s1, "X:");
+  call_string_cat_vprintf(s1, "%#");
   assert(string_equal_str_p(s1, "X:") == true);
 
   string_set_str(s1, " \r\n\t HELLO  \n\r\t");


### PR DESCRIPTION
It seems weird that there are both `m_string_printf` and `m_string_vprintf` but `m_string_cat_printf` doesn't have a `vprintf` variant, so here I add the missing function.
I think because of this, flipperzero firmware (that uses m-string) has to allocate a new string in its [string_cat_vprintf implementation](https://github.com/flipperdevices/flipperzero-firmware/blob/538f96f0ac43576383620b0faa0686ca35207b49/furi/core/string.c#L176) instead of just delegating to an appropriate `vprintf` function, like it does in its `string_vprintf` [here](https://github.com/flipperdevices/flipperzero-firmware/blob/538f96f0ac43576383620b0faa0686ca35207b49/furi/core/string.c#L164).