### PR TITLE
Provide way of avoiding code duplication for multiple source C files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ depend
 other/
 a*.dat
 config
+config.link
 *.log
 .vscode
 .vs

--- a/README.md
+++ b/README.md
@@ -8342,6 +8342,45 @@ Use fast integer conversion algorithms instead of using the LIBC.
 
 Default value: 1 (because it also generates smaller code).
 
+#### M\_USE\_DECL
+
+If M\_USE\_FINE\_GRAINED\_LINKAGE is not defined,
+it will request M\*LIB to change the linkage of its symbols globally:
+instead of inlining the functions, it will emit weak symbols
+for the functions that are not inlined.
+
+And in exactly one translation unit, the macro M\_USE\_DEF
+should also be defined so that it emits the normal definition
+of the functions. In which case, it should contain all symbols
+used by all other translation units.
+
+You should compile your program with 
+-ffunction-sections -fdata-sections 
+and link with
+-Wl,--gc-sections
+in order to remove unused code and to merge identical code
+otherwise it is likely to generate even bigger code than using the inlining linkage.
+
+This works for GCC / CLANG in C mode.
+
+#### M\_USE\_FINE\_GRAINED\_LINKAGE
+
+It will request M\*LIB to change the linkage of its symbols dynamically at compile time:
+in which case
+M\_USE\_DECL / M\_USE\_DEF can be defined / undefined several times in a translation unit
+and M\*LIB will emit the change the linkage of the symbols being declared accordingly:
+
+* definition like if M\_USE\_DECL and M\_USE\_DEF are defined
+* declaration like if M\_USE\_DECL is defined
+* inline like otherwise
+
+This enables to inline some functions and not others.
+
+M\_USE\_DECL / M\_USE\_DEF shall be defined without effective value.
+
+See M\_USE\_DECL for more details.
+
+
 #### M\_MEMORY\_ALLOC
 
 See [m-core.h](#m-core)

--- a/example/Makefile
+++ b/example/Makefile
@@ -34,6 +34,7 @@ RM=rm -f
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ `cat config` $(LDFLAGS)
 
 .c.o:
+	@$(MAKE) config
 	$(CC) $(CFLAGS) $(CPPFLAGS) -O2 `cat config.link` -DNDEBUG -g $< -c -o $@
 
 all: config

--- a/example/Makefile
+++ b/example/Makefile
@@ -21,7 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CC=cc -std=c99
-CFLAGS=-Wall -W -pedantic -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -Wswitch-default -Wswitch-enum -Wcast-align -Wpointer-arith -Wbad-function-cast -Wstrict-overflow=5 -Wstrict-prototypes -Winline -Wundef -Wnested-externs -Wcast-qual -Wshadow -Wunreachable-code -Wlogical-op -Wstrict-aliasing=2 -Wredundant-decls -Wold-style-definition -Wno-unused-function -g
+CFLAGS=-Wall -W -pedantic -Wshadow -Wpointer-arith -Wcast-qual -Wstrict-prototypes -Wmissing-prototypes -Wswitch-default -Wswitch-enum -Wcast-align -Wpointer-arith -Wbad-function-cast -Wstrict-overflow=5 -Wstrict-prototypes -Wundef -Wnested-externs -Wcast-qual -Wshadow -Wunreachable-code -Wlogical-op -Wstrict-aliasing=2 -Wredundant-decls -Wold-style-definition -Wno-unused-function -g
 GMP_DIR=
 MPFR_DIR=$(GMP_DIR)
 CPPFLAGS=-I..
@@ -33,9 +33,19 @@ RM=rm -f
 .c.exe:
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ `cat config` $(LDFLAGS)
 
+.c.o:
+	$(CC) $(CFLAGS) $(CPPFLAGS) -O2 -ffunction-sections -fdata-sections -DNDEBUG -g $< -c -o $@ `cat config` $(LDFLAGS)
+
 all: config
 	$(MAKE) `ls ex-*.c|sed -e 's/\.c/\.exe/g'`
 	if test "$(CC)" = "cc -std=c99" ; then $(MAKE) `ls ex11-*.c|sed -e 's/\.c/\.exe/g'` CC="cc -std=c11" ; fi
+	$(MAKE) exm.exe
+
+exm.exe: exm-lib.o exm-main.o
+	$(CC) -Wl,--gc-sections -g $^ -o $@
+
+exn.exe: exn-lib.o exn-main.o
+	$(CC) -Wl,--gc-sections -g $^ -o $@
 
 config:
 	printf "#include <gmp.h>\nint main(void){mpz_t z; mpz_init(z); return 0;}\n" > config-test.c

--- a/example/Makefile
+++ b/example/Makefile
@@ -34,7 +34,7 @@ RM=rm -f
 	$(CC) $(CFLAGS) $(CPPFLAGS) $< -o $@ `cat config` $(LDFLAGS)
 
 .c.o:
-	$(CC) $(CFLAGS) $(CPPFLAGS) -O2 -ffunction-sections -fdata-sections -DNDEBUG -g $< -c -o $@ `cat config` $(LDFLAGS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) -O2 `cat config.link` -DNDEBUG -g $< -c -o $@
 
 all: config
 	$(MAKE) `ls ex-*.c|sed -e 's/\.c/\.exe/g'`
@@ -42,19 +42,21 @@ all: config
 	$(MAKE) exm.exe exn.exe
 
 exm.exe: exm-lib.o exm-main.o
-	$(CC) -Wl,--gc-sections -g $^ -o $@
+	$(CC) `cat config.link` -g $^ -o $@
 
 exn.exe: exn-lib.o exn-main.o
-	$(CC) -Wl,--gc-sections -g $^ -o $@
+	$(CC) `cat config.link` -g $^ -o $@
 
 config:
 	printf "#include <gmp.h>\nint main(void){mpz_t z; mpz_init(z); return 0;}\n" > config-test.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(GMP_DIR)/include -L$(GMP_DIR)/lib config-test.c -lgmp -o config-test.exe $(LDFLAGS) 2> /dev/null && echo "-DHAVE_GMP=1 -DHAVE_MPFR=0 -I$(GMP_DIR)/include -L$(GMP_DIR)/lib -lgmp" > config || echo "-DHAVE_GMP=0 -DHAVE_MPFR=0 " > config
 	printf "#include <mpfr.h>\nint main(void){mpfr_t z; mpfr_init(z); return 0;}\n" > config-test.c
 	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(GMP_DIR)/include -I$(MPFR_DIR)/include -L$(GMP_DIR)/lib -L$(MPFR_DIR)/lib config-test.c -lmpfr -lgmp -o config-test.exe $(LDFLAGS) 2> /dev/null && echo "-DHAVE_GMP=1 -DHAVE_MPFR=1  -I$(GMP_DIR)/include -L$(GMP_DIR)/lib -I$(MPFR_DIR)/include -L$(MPFR_DIR)/lib -lmpfr -lgmp" > config || echo "MPFR not available"
+	printf "#include <stdio.h>\nint main(void){printf(\"Ok\"); return 0;}\n" > config-test.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) config-test.c -ffunction-sections -fdata-sections -Wl,--gc-sections 2> /dev/null && echo "-ffunction-sections -fdata-sections -Wl,--gc-sections" > config.link || echo "" > config.link
 	$(RM) config-test.c config-test.exe
 
 clean:
-	$(RM) *.exe *.s *~ *.o ./a.dat config
+	$(RM) *.exe *.s *~ *.o ./a.dat config config.link
 
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -39,7 +39,7 @@ RM=rm -f
 all: config
 	$(MAKE) `ls ex-*.c|sed -e 's/\.c/\.exe/g'`
 	if test "$(CC)" = "cc -std=c99" ; then $(MAKE) `ls ex11-*.c|sed -e 's/\.c/\.exe/g'` CC="cc -std=c11" ; fi
-	$(MAKE) exm.exe
+	$(MAKE) exm.exe exn.exe
 
 exm.exe: exm-lib.o exm-main.o
 	$(CC) -Wl,--gc-sections -g $^ -o $@

--- a/example/exm-header.h
+++ b/example/exm-header.h
@@ -1,0 +1,14 @@
+#ifndef MY_HEADER
+#define MY_HEADER
+
+// Request M*LIB to not inline functions if not the library source
+#ifndef M_USE_EXTERN_DEF
+#define M_USE_EXTERN_DECL
+#endif
+#include "m-string.h"
+#include "m-array.h"
+
+ARRAY_DEF(array_str, string_t)
+
+#endif
+

--- a/example/exm-header.h
+++ b/example/exm-header.h
@@ -2,7 +2,7 @@
 #define MY_HEADER
 
 // Request M*LIB to not inline functions if not the library source
-#define M_USE_EXTERN_DECL
+#define M_USE_DECL
 #include "m-string.h"
 #include "m-array.h"
 

--- a/example/exm-header.h
+++ b/example/exm-header.h
@@ -2,9 +2,7 @@
 #define MY_HEADER
 
 // Request M*LIB to not inline functions if not the library source
-#ifndef M_USE_EXTERN_DEF
 #define M_USE_EXTERN_DECL
-#endif
 #include "m-string.h"
 #include "m-array.h"
 

--- a/example/exm-lib.c
+++ b/example/exm-lib.c
@@ -1,0 +1,4 @@
+// Request M*LIB to define functions
+// This include both m-string functions and array_str templated functions
+#define M_USE_EXTERN_DEF
+#include "exm-header.h"

--- a/example/exm-lib.c
+++ b/example/exm-lib.c
@@ -1,4 +1,5 @@
 // Request M*LIB to define functions
 // This include both m-string functions and array_str templated functions
+// Defining M_USE_EXTERN_DEF override M_USE_EXTERN_DECL definition
 #define M_USE_EXTERN_DEF
 #include "exm-header.h"

--- a/example/exm-lib.c
+++ b/example/exm-lib.c
@@ -1,5 +1,5 @@
 // Request M*LIB to define functions
 // This include both m-string functions and array_str templated functions
 // Defining M_USE_EXTERN_DEF override M_USE_EXTERN_DECL definition
-#define M_USE_EXTERN_DEF
+#define M_USE_DEF
 #include "exm-header.h"

--- a/example/exm-main.c
+++ b/example/exm-main.c
@@ -1,0 +1,14 @@
+#include "exm-header.h"
+
+int main(void)
+{
+  array_str_t a;
+  array_str_init(a);
+  array_str_emplace_back(a, "Hello");
+  array_str_emplace_back(a, "World");
+  printf("a=");
+  array_str_out_str(stdout, a);
+  printf("\n");
+  array_str_clear(a);
+  return 0;
+}

--- a/example/exn-header.h
+++ b/example/exn-header.h
@@ -2,7 +2,7 @@
 #define MY_HEADER
 
 // Request M*LIB to not always inline functions
-#define M_USE_EXTERN_FINE_GRAINED 1
+#define M_USE_FINE_GRAINED_LINKAGE
 #include "m-string.h"
 #include "m-array.h"
 

--- a/example/exn-header.h
+++ b/example/exn-header.h
@@ -1,0 +1,19 @@
+#ifndef MY_HEADER
+#define MY_HEADER
+
+// Request M*LIB to not always inline functions
+#define M_USE_EXTERN_FINE_GRAINED 1
+#include "m-string.h"
+#include "m-array.h"
+
+// The following functions will not be inlined:
+#undef M_USE_EXTERN_FINE_SELECT
+#ifdef EXN_LIB
+#define M_USE_EXTERN_FINE_SELECT 3
+#else
+#define M_USE_EXTERN_FINE_SELECT 2
+#endif
+
+ARRAY_DEF(array_str, string_t)
+
+#endif

--- a/example/exn-header.h
+++ b/example/exn-header.h
@@ -7,13 +7,8 @@
 #include "m-array.h"
 
 // The following functions will not be inlined:
-#undef M_USE_EXTERN_FINE_SELECT
-#ifdef EXN_LIB
-#define M_USE_EXTERN_FINE_SELECT 3
-#else
-#define M_USE_EXTERN_FINE_SELECT 2
-#endif
-
+#define M_USE_DECL
 ARRAY_DEF(array_str, string_t)
+#undef M_USE_DECL
 
 #endif

--- a/example/exn-lib.c
+++ b/example/exn-lib.c
@@ -1,4 +1,4 @@
 // Request M*LIB to define functions for functions defined within M_USE_DECL.
-#define M_USE_DEF 1
+#define M_USE_DEF
 #include "exn-header.h"
 

--- a/example/exn-lib.c
+++ b/example/exn-lib.c
@@ -1,4 +1,4 @@
-// Request M*LIB to define functions for templated array functions.
-#define EXN_LIB 3
+// Request M*LIB to define functions for functions defined within M_USE_DECL.
+#define M_USE_DEF 1
 #include "exn-header.h"
 

--- a/example/exn-lib.c
+++ b/example/exn-lib.c
@@ -1,0 +1,4 @@
+// Request M*LIB to define functions for templated array functions.
+#define EXN_LIB 3
+#include "exn-header.h"
+

--- a/example/exn-main.c
+++ b/example/exn-main.c
@@ -1,0 +1,19 @@
+#include "exn-header.h"
+
+int main(void)
+{
+  string_t s;
+  string_init_set_str(s, "a=");
+  string_fputs(stdout, s);
+  string_clear(s);
+  array_str_t a;
+  array_str_init(a);
+  array_str_emplace_back(a, "Hello");
+  array_str_emplace_back(a, "World");
+  //printf("a=");
+  array_str_out_str(stdout, a);
+  printf("\n");
+  array_str_clear(a);
+  //main2();
+  return 0;
+}

--- a/m-algo.h
+++ b/m-algo.h
@@ -28,7 +28,7 @@
 #include "m-core.h"
 
 /* Define different kind of basic algorithms named 'name' over the container
-   which oplist is 'cont_oplist', as static inline functions.
+   which oplist is 'cont_oplist'.
    USAGE:
    ALGO_DEF(algogName, containerOplist|type if oplist has been registered) */
 #define M_ALGO_DEF(name, cont_oplist)                                         \
@@ -189,7 +189,7 @@
 #define M_ALG0_DEF_SORT(name, container_t, cont_oplist, type_t, type_oplist, it_t, order, sort_name) \
                                                                               \
   /* Define the encapsulation function that perform the selected order */     \
-  static inline int M_C3(name,sort_name,_cmp)(type_t const*a,type_t const*b)  \
+  M_INLINE int M_C3(name,sort_name,_cmp)(type_t const*a,type_t const*b)       \
   {                                                                           \
     return order M_CALL_CMP(type_oplist, *a, *b);                             \
   }                                                                           \
@@ -225,7 +225,7 @@
 #define M_ALG0_DEF_SORT_AUX(name, container_t, cont_oplist, type_t, type_oplist, it_t, sort_name, cmp_func, cmp_param, cmp_arg) \
                                                                               \
   /* Test if the container is sorted */                                       \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C3(name,sort_name,_p)(const container_t l cmp_param(name))                \
   {                                                                           \
     it_t it1;                                                                 \
@@ -253,7 +253,7 @@
   /*  - a selection sort */                                                   \
   M_IF(M_AND(M_TEST_METHOD_P(SORT, cont_oplist), M_EMPTY_P(cmp_arg)))(        \
     /******** OPTIMIZED SORT FOR CONTAINER *********/                         \
-  static inline void M_F(name,sort_name)(container_t l)                       \
+  M_INLINE void M_F(name,sort_name)(container_t l)                            \
   {                                                                           \
     M_CALL_SORT(cont_oplist, l, M_C3(name, sort_name,_cmp));                  \
   }                                                                           \
@@ -265,7 +265,7 @@
                                                                               \
   /* Split the container 'l' into near even size l1 and l2 *                  \
      using odd/even splitting  */                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name,sort_name,_split)(container_t l1, container_t l2, container_t l)  \
   {                                                                           \
     it_t it;                                                                  \
@@ -280,7 +280,7 @@
   }                                                                           \
                                                                               \
   /* Merge in empty 'l' the sorted container 'l1' and 'l2' */                 \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name,sort_name,_merge)(container_t l, container_t l1, container_t l2 cmp_param(name)) \
   {                                                                           \
     /* M_ASSERT(M_CALL_EMPTY_P (cont_oplist, l)); */                          \
@@ -320,7 +320,7 @@
   }                                                                           \
                                                                               \
   /* Sort the container 'l' */                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,sort_name)(container_t l cmp_param(name))                          \
   {                                                                           \
     container_t l1;                                                           \
@@ -363,7 +363,7 @@
                                         ,                                     \
   M_IF_METHOD(IT_PREVIOUS, cont_oplist)(                                      \
     /******** GENERIC INSERTION SORT *********/                               \
-  static inline void M_F(name,sort_name)(container_t l cmp_param(name))       \
+  M_INLINE void M_F(name,sort_name)(container_t l cmp_param(name))            \
   {                                                                           \
     it_t it1;                                                                 \
     it_t it2;                                                                 \
@@ -400,7 +400,7 @@
                                                                               \
   ,                                                                           \
   /********** GENERIC SELECTION SORT ************/                            \
-  static inline void M_F(name,sort_name)(container_t l cmp_param(name))       \
+  M_INLINE void M_F(name,sort_name)(container_t l cmp_param(name))            \
   {                                                                           \
     it_t it1;                                                                 \
     it_t it2;                                                                 \
@@ -433,7 +433,7 @@
                                                                         ) /* IF SORT METHOD */ \
   /* Compute the union of two ***sorted*** containers  */                     \
   M_IF_METHOD(IT_INSERT, cont_oplist)(                                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name,sort_name,_union)(container_t dst, const container_t src cmp_param(name)) \
   {                                                                           \
     it_t itSrc;                                                               \
@@ -478,7 +478,7 @@
                                                                               \
   /* Compute the intersection of two ***sorted*** containers  */              \
   M_IF_METHOD(IT_REMOVE, cont_oplist)(                                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name,sort_name,_intersect)(container_t dst, const container_t src cmp_param(name)) \
   {                                                                           \
     it_t itSrc;                                                               \
@@ -517,7 +517,7 @@
 #define M_ALG0_DEF_FIND(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
   /* It supposes that the container is not sorted */                          \
   /* Find the next occurrence from it (included) of data */                   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _find_again) (it_t it, type_t const data)                         \
   {                                                                           \
     for ( /*nothing*/ ; !M_CALL_IT_END_P(cont_oplist, it) ;                   \
@@ -528,7 +528,7 @@
   }                                                                           \
                                                                               \
   /* Find the first occurrence of data */                                     \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _find) (it_t it, container_t const l, type_t const data)          \
   {                                                                           \
     M_CALL_IT_FIRST(cont_oplist, it, l);                                      \
@@ -536,7 +536,7 @@
   }                                                                           \
                                                                               \
   /* Test if data is within the container */                                  \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _contain_p) (container_t const l, type_t const data)              \
   {                                                                           \
     it_t it;                                                                  \
@@ -549,7 +549,7 @@
      PREVIOUS & IT_LAST are defined, then search backwards */                 \
   M_IF_METHOD2(PREVIOUS, IT_LAST, cont_oplist)                                \
   (                                                                           \
-   static inline void                                                         \
+   M_INLINE void                                                              \
    M_F(name, _find_last) (it_t it, container_t const l, type_t const data)    \
    {                                                                          \
      for (M_CALL_IT_LAST(cont_oplist, it, l);                                 \
@@ -562,7 +562,7 @@
    }                                                                          \
    ,                                                                          \
    /* Otherwise search forward, but don't stop on the first occurrence */     \
-   static inline void                                                         \
+   M_INLINE void                                                              \
    M_F(name, _find_last) (it_t it, container_t const l, type_t const data)    \
    {                                                                          \
      M_CALL_IT_END(cont_oplist, it, l);                                       \
@@ -578,7 +578,7 @@
    ) /* End of alternative of _find_last */                                   \
                                                                               \
   /* Count the number of occurrence of data in the container */               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _count) (container_t const l, type_t const data)                  \
   {                                                                           \
     it_t it;                                                                  \
@@ -594,7 +594,7 @@
                                                                               \
                                                                               \
   /* Find the next mismatch between the containers */                         \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _mismatch_again) (it_t it1, it_t it2)                             \
   {                                                                           \
     for (/* nothing */ ; !M_CALL_IT_END_P(cont_oplist, it1) &&                \
@@ -608,7 +608,7 @@
   }                                                                           \
                                                                               \
   /* Find the first mismatch between the containers */                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _mismatch) (it_t it1, it_t it2, container_t const l1, container_t const l2 ) \
   {                                                                           \
     M_CALL_IT_FIRST(cont_oplist, it1, l1);                                    \
@@ -625,7 +625,7 @@
 #define M_ALG0_DEF_FIND_IF(name, container_t, cont_oplist, type_t, type_oplist, it_t, suffix, test_t, eq_t, call_test, call_eq) \
                                                                               \
   /* Find the next occurrence that matches the condition */                   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _find_again_, suffix) (it_t it, test_t func)                     \
   {                                                                           \
     for (/*nothing */ ; !M_CALL_IT_END_P(cont_oplist, it) ;                   \
@@ -636,7 +636,7 @@
   }                                                                           \
                                                                               \
   /* Find the first occurrence that matches the condition */                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _find_, suffix) (it_t it, container_t l, test_t func)            \
   {                                                                           \
     M_CALL_IT_FIRST(cont_oplist, it, l);                                      \
@@ -644,7 +644,7 @@
   }                                                                           \
                                                                               \
   /* Count the number of occurrence that matches the condition */             \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_C3(name, _count_, suffix) (container_t const l, test_t func)              \
   {                                                                           \
     it_t it;                                                                  \
@@ -660,7 +660,7 @@
   }                                                                           \
                                                                               \
   /* Find the next mismatch between the containers according to the condition */ \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _mismatch_again_, suffix) (it_t it1, it_t it2, eq_t func)        \
   {                                                                           \
     for (/*nothing */ ; !M_CALL_IT_END_P(cont_oplist, it1) &&                 \
@@ -674,7 +674,7 @@
   }                                                                           \
                                                                               \
   /* Find the first mismatch between the containers according to the condition */ \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _mismatch_, suffix) (it_t it1, it_t it2, container_t const l1,   \
                            container_t l2, eq_t func)                         \
   {                                                                           \
@@ -688,7 +688,7 @@
 #define M_ALG0_DEF_FILL(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
                                                                               \
   /* Fill all the container with value (overwritten) */                       \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _fill) (container_t l, type_t const value)                        \
   {                                                                           \
     for M_EACH(item, l, cont_oplist) {                                        \
@@ -698,7 +698,7 @@
                                                                               \
   /* Fill the container with exactly 'n' occurrence of 'value' */             \
   M_IF_METHOD(PUSH, cont_oplist)(                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _fill_n) (container_t l, size_t n, type_t const value)            \
   {                                                                           \
     M_CALL_RESET(cont_oplist, l);                                             \
@@ -710,7 +710,7 @@
                                                                               \
   /* Fill the container with FOR('value'; 'value'+'inc') */                   \
   M_IF_METHOD(ADD, type_oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _fill_a) (container_t l, type_t const value, type_t const inc)    \
   {                                                                           \
     type_t tmp;                                                               \
@@ -724,7 +724,7 @@
                                                                               \
   /* Fill the container with n occurences of FOR('value'; 'value'+'inc') */   \
   M_IF_METHOD(PUSH, cont_oplist)(                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _fill_an) (container_t l, size_t n, type_t const value, type_t const inc) \
   {                                                                           \
     type_t tmp;                                                               \
@@ -744,7 +744,7 @@
 #define M_ALG0_DEF_MAP(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
                                                                               \
   /* Apply func for all elements of the container */                          \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _for_each) (container_t l, M_F(name, _apply_cb_ct) func)          \
   {                                                                           \
     for M_EACH(item, l, cont_oplist) {                                        \
@@ -756,7 +756,7 @@
   M_IF_METHOD(PUSH_MOVE, cont_oplist)(                                        \
                                                                               \
   /* Apply func for all elements of the container src and push the result in dst */ \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _transform) (container_t dst,                                     \
                          container_t src,                                     \
                         M_F(name, _transform_cb_ct) func)                     \
@@ -775,7 +775,7 @@
                                                                               \
   /* Reduce all elements of the container in dst in function of func */       \
   M_IF_METHOD(SET, type_oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reduce) (type_t *dest, container_t const l,                      \
                       M_F(name, _transform_cb_ct) func)                       \
   {                                                                           \
@@ -793,7 +793,7 @@
                                                                               \
   /* Reduce all transformed elements of the container in dst in function of func */ \
   M_IF_METHOD(INIT, type_oplist)(                                             \
-  static inline                                                               \
+  M_INLINE                                                                    \
   void M_F(name, _map_reduce) (type_t *dest,                                  \
                                const container_t l,                           \
                                M_F(name, _transform_cb_ct) redFunc,           \
@@ -819,7 +819,7 @@
 /* Define ALL_OF algorithms */
 #define M_ALG0_DEF_ALL_OF(name, container_t, cont_oplist, type_t, type_oplist, it_t, suffix, func_t, call) \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C4(name, _any_of, suffix, p) (container_t const l,                        \
                                   func_t func )                               \
   {                                                                           \
@@ -830,7 +830,7 @@
     return false;                                                             \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C4(name, _all_of, suffix, p) (container_t const l,                        \
                                   func_t func )                               \
   {                                                                           \
@@ -841,7 +841,7 @@
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C4(name, _none_of, suffix, p) (container_t l,                             \
                                     func_t func )                             \
   {                                                                           \
@@ -856,7 +856,7 @@
 /* Define MIN / MAX algorithms */
 #define M_ALG0_DEF_MINMAX(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
                                                                               \
-  static inline type_t *                                                      \
+  M_INLINE type_t *                                                           \
   M_F(name, _min) (const container_t l)                                       \
   {                                                                           \
     type_t *min = NULL;                                                       \
@@ -869,7 +869,7 @@
     return min;                                                               \
   }                                                                           \
                                                                               \
-  static inline type_t *                                                      \
+  M_INLINE type_t *                                                           \
   M_F(name, _max) (const container_t l)                                       \
   {                                                                           \
     type_t *max = NULL;                                                       \
@@ -882,7 +882,7 @@
     return max;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _minmax) (type_t **min_p, type_t **max_p,                         \
                       const container_t l)                                    \
   {                                                                           \
@@ -905,7 +905,7 @@
 /* Define functions based on remove method */
 #define M_ALG0_DEF_REMOVE(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _uniq)(container_t l)                                             \
   {                                                                           \
     it_t it1;                                                                 \
@@ -927,7 +927,7 @@
       }                                                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove_val)(container_t l, type_t const val)                     \
   {                                                                           \
     it_t it1;                                                                 \
@@ -942,7 +942,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove_if)(container_t l, M_F(name, _test_cb_ct) func)           \
   {                                                                           \
     it_t it1;                                                                 \
@@ -961,7 +961,7 @@
 #define M_ALG0_DEF_VECTOR(name, container_t, cont_oplist, type_t, type_oplist, it_t) \
                                                                               \
   M_IF_METHOD(ADD, type_oplist)(                                              \
-  static inline void M_F(name, _add) (container_t dst, const container_t src) \
+  M_INLINE void M_F(name, _add) (container_t dst, const container_t src)      \
   {                                                                           \
     it_t itSrc;                                                               \
     it_t itDst;                                                               \
@@ -979,7 +979,7 @@
   , /* NO_ADD METHOD */ )                                                     \
                                                                               \
   M_IF_METHOD(SUB, type_oplist)(                                              \
-  static inline void M_F(name, _sub) (container_t dst, const container_t src) \
+  M_INLINE void M_F(name, _sub) (container_t dst, const container_t src)      \
   {                                                                           \
     it_t itSrc;                                                               \
     it_t itDst;                                                               \
@@ -997,7 +997,7 @@
   , /* NO_SUB METHOD */ )                                                     \
                                                                               \
   M_IF_METHOD(MUL, type_oplist)(                                              \
-  static inline void M_F(name, _mul) (container_t dst, const container_t src) \
+  M_INLINE void M_F(name, _mul) (container_t dst, const container_t src)      \
   {                                                                           \
     it_t itSrc;                                                               \
     it_t itDst;                                                               \
@@ -1015,7 +1015,7 @@
   , /* NO_MUL METHOD */ )                                                     \
                                                                               \
   M_IF_METHOD(DIV, type_oplist)(                                              \
-  static inline void M_F(name, _div) (container_t dst, const container_t src) \
+  M_INLINE void M_F(name, _div) (container_t dst, const container_t src)      \
   {                                                                           \
     it_t itSrc;                                                               \
     it_t itDst;                                                               \

--- a/m-array.h
+++ b/m-array.h
@@ -201,7 +201,7 @@
 /* Define the core functions */
 #define M_ARRA4_DEF_CORE(name, type, oplist, array_t, it_t)                   \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(array_t v)                                                 \
   {                                                                           \
     M_ASSERT (v != NULL);                                                     \
@@ -212,7 +212,7 @@
     M_ARRA4_CONTRACT(v);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(array_t v)                                                \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -222,7 +222,7 @@
     M_ARRA4_CONTRACT(v);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(array_t v)                                                \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -234,7 +234,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD2(INIT_SET, SET, oplist)(                                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(array_t d, const array_t s)                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(d);                                                      \
@@ -262,7 +262,7 @@
     M_ARRA4_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(array_t d, const array_t s)                            \
   {                                                                           \
     M_ASSERT (d != s);                                                        \
@@ -271,7 +271,7 @@
   }                                                                           \
   , /* No SET & INIT_SET */)                                                  \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(array_t d, array_t s)                                 \
   {                                                                           \
     M_ASSERT (d != s);                                                        \
@@ -285,7 +285,7 @@
     M_ARRA4_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(array_t d, array_t s)                                      \
   {                                                                           \
     M_ASSERT (d != s);                                                        \
@@ -294,7 +294,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(SET, oplist)(                                                   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_at)(array_t v, size_t i, type const x)                       \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -304,7 +304,7 @@
   }                                                                           \
   , /* No SET */)                                                             \
                                                                               \
-  static inline type  *                                                       \
+  M_INLINE type  *                                                            \
   M_F(name, _back)(array_t v)                                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -313,7 +313,7 @@
     return &v->ptr[v->size-1];                                                \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_raw)(array_t v)                                             \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -342,7 +342,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT_SET, oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back)(array_t v, type const x)                              \
   {                                                                           \
     type *data = M_F(name, _push_raw)(v);                                     \
@@ -353,7 +353,7 @@
   , /* No INIT_SET */ )                                                       \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_new)(array_t v)                                             \
   {                                                                           \
     type *data = M_F(name, _push_raw)(v);                                     \
@@ -365,7 +365,7 @@
   , /* No INIT */ )                                                           \
                                                                               \
   M_IF_AT_LEAST_METHOD(INIT_SET, INIT_MOVE, oplist)(                          \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_move)(array_t v, type *x)                                   \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -377,7 +377,7 @@
   , /* INIT_SET | INIT_MOVE */ )                                              \
                                                                               \
   M_IF_METHOD(INIT_SET, oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_at)(array_t v, size_t key, type const x)                    \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -407,7 +407,7 @@
   , /* No INIT_SET */ )                                                       \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _resize)(array_t v, size_t size)                                  \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -436,7 +436,7 @@
   }                                                                           \
   , /* No INIT */ )                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reserve)(array_t v, size_t alloc)                                \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -461,7 +461,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _safe_get)(array_t v, size_t idx)                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -495,7 +495,7 @@
   , /* No INIT */)                                                            \
                                                                               \
   M_IF_AT_LEAST_METHOD(SET, INIT_MOVE, oplist)(                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_back)(type *dest, array_t v)                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -512,7 +512,7 @@
   , /* SET | INIT_MOVE */ )                                                   \
                                                                               \
   M_IF_AT_LEAST_METHOD(INIT_SET, INIT_MOVE, oplist)(                          \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_move)(type *dest, array_t v)                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -526,7 +526,7 @@
   , /* INIT_SET | INIT_MOVE */ )                                              \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_until)(array_t v, it_t pos)                                  \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -536,21 +536,21 @@
   }                                                                           \
   , /* No INIT */ )                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const array_t v)                                        \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
     return v->size == 0;                                                      \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const array_t v)                                           \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
     return v->size;                                                           \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity)(const array_t v)                                       \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -558,7 +558,7 @@
   }                                                                           \
                                                                               \
   M_IF_AT_LEAST_METHOD(SET, INIT_MOVE, oplist)(                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_at)(type *dest, array_t v, size_t i)                         \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -573,7 +573,7 @@
     M_ARRA4_CONTRACT(v);                                                      \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _erase)(array_t a, size_t i)                                      \
   {                                                                           \
     M_ARRA4_CONTRACT(a);                                                      \
@@ -584,7 +584,7 @@
   , /* SET | INIT_MOVE */ )                                                   \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _insert_v)(array_t v, size_t i, size_t num)                       \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -620,7 +620,7 @@
   }                                                                           \
   , /* No INIT */)                                                            \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove_v)(array_t v, size_t i, size_t j)                         \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -634,7 +634,7 @@
     M_ARRA4_CONTRACT(v);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(array_t v1, array_t v2)                                    \
   {                                                                           \
     M_ARRA4_CONTRACT(v1);                                                     \
@@ -647,7 +647,7 @@
   }                                                                           \
                                                                               \
   M_IF_AT_LEAST_METHOD(INIT_SET,INIT_MOVE,oplist) (                           \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap_at)(array_t v, size_t i, size_t j)                          \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -662,7 +662,7 @@
   }                                                                           \
   , /* INIT_SET | INIT_MOVE */ )                                              \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _get)(const array_t v, size_t i)                                  \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -671,7 +671,7 @@
     return &v->ptr[i];                                                        \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cget)(const array_t v, size_t i)                                 \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -680,7 +680,7 @@
     return M_CONST_CAST(type, &v->ptr[i]);                                    \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _front)(const array_t v)                                          \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -688,7 +688,7 @@
     return M_F(name, _get)(v, 0);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const array_t v)                                    \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -697,7 +697,7 @@
     it->array = v;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(it_t it, const array_t v)                               \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -707,7 +707,7 @@
     it->array = v;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, const array_t v)                                \
   {                                                                           \
     M_ARRA4_CONTRACT(v);                                                      \
@@ -716,7 +716,7 @@
     it->array = v;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it, const it_t org)                                 \
   {                                                                           \
     M_ASSERT (it != NULL && org != NULL);                                     \
@@ -725,14 +725,14 @@
     M_ARRA4_CONTRACT(it->array);                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     M_ASSERT(it != NULL && it->array != NULL);                                \
     return it->index >= it->array->size;                                      \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const it_t it)                                           \
   {                                                                           \
     M_ASSERT(it != NULL && it->array != NULL);                                \
@@ -741,7 +741,7 @@
     return it->index + 1 >= it->array->size;                                  \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1,                                      \
                          const it_t it2)                                      \
   {                                                                           \
@@ -749,14 +749,14 @@
     return it1->array == it2->array && it1->index == it2->index;              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT(it != NULL && it->array != NULL);                                \
     it->index ++;                                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(it_t it)                                               \
   {                                                                           \
     M_ASSERT(it != NULL && it->array != NULL);                                \
@@ -765,14 +765,14 @@
     it->index --;                                                             \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(const it_t it)                                              \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
     return M_F(name, _get)(it->array, it->index);                             \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
@@ -780,7 +780,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT_SET, oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _insert)(array_t a, it_t it, type const x)                        \
   {                                                                           \
     M_ASSERT (it != NULL && a == it->array);                                  \
@@ -791,7 +791,7 @@
   , /* End of INIT_SET */ )                                                   \
                                                                               \
   M_IF_AT_LEAST_METHOD(SET, INIT_MOVE, oplist)(                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove)(array_t a, it_t it)                                      \
   {                                                                           \
     M_ASSERT (it != NULL && a == it->array);                                  \
@@ -802,7 +802,7 @@
                                                                               \
   M_IF_METHOD(CMP, oplist)                                                    \
   (                                                                           \
-   static inline void M_F(name, _special_sort)(array_t l,                     \
+   M_INLINE void M_F(name, _special_sort)(array_t l,                          \
               int (*func_type) (type const *a, type const *b))                \
   {                                                                           \
     /* Using qsort is more compact but slower than a full templated           \
@@ -814,7 +814,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD2(SWAP, SET, oplist)(                                            \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_arra4_,name,_stable_sort_noalloc)(type tab[], size_t size, type tmp[]) \
   {                                                                           \
     size_t th = 4;                                                            \
@@ -885,7 +885,7 @@
     M_ASSERT (org_tab == tab);                                                \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _special_stable_sort)(array_t l)                                  \
   {                                                                           \
     if (M_UNLIKELY (l->size < 2))                                             \
@@ -904,7 +904,7 @@
   ,) /* IF CMP oplist */                                                      \
                                                                               \
   M_IF_METHOD(EQUAL, oplist)(                                                 \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const array_t array1,                                   \
                       const array_t array2)                                   \
   {                                                                           \
@@ -923,7 +923,7 @@
   , /* no EQUAL */ )                                                          \
                                                                               \
   M_IF_METHOD(HASH, oplist)(                                                  \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _hash)(const array_t array)                                       \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -936,7 +936,7 @@
   }                                                                           \
   , /* no HASH */ )                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(array_t a1, array_t a2)                                  \
   {                                                                           \
     M_ARRA4_CONTRACT(a1);                                                     \
@@ -969,7 +969,7 @@
 #define M_ARRA4_DEF_IO(name, type, oplist, array_t, it_t)                     \
                                                                               \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t str, array_t const array,                    \
                       bool append)                                            \
   {                                                                           \
@@ -989,7 +989,7 @@
   , /* no GET_STR */ )                                                        \
                                                                               \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, const array_t array)                        \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -1006,7 +1006,7 @@
   , /* no OUT_STR */ )                                                        \
                                                                               \
   M_IF_METHOD2(PARSE_STR, INIT, oplist)(                                      \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(array_t array, const char str[], const char**endp)    \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -1034,7 +1034,7 @@
   , /* no PARSE_STR & INIT */ )                                               \
                                                                               \
   M_IF_METHOD2(IN_STR, INIT, oplist)(                                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(array_t array, FILE *file)                               \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -1060,7 +1060,7 @@
   , /* no IN_STR & INIT */ )                                                  \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, const array_t array)             \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -1081,7 +1081,7 @@
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD2(IN_SERIAL, INIT, oplist)(                                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(array_t array, m_serial_read_t f)                     \
   {                                                                           \
     M_ARRA4_CONTRACT(array);                                                  \
@@ -1110,7 +1110,7 @@
 
 /* Definition of the emplace_back function for arrays */
 #define M_ARRA4_EMPLACE_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \

--- a/m-atomic.h
+++ b/m-atomic.h
@@ -226,7 +226,7 @@ typedef _Atomic(uintmax_t)          atomic_uintmax_t;
 #endif
 
 /* (INTERNAL) Unlock the mutex and return the given value */
-static inline long long atomic_fetch_unlock (m_mutex_t *lock, long long val)
+M_INLINE long long atomic_fetch_unlock (m_mutex_t *lock, long long val)
 {
   m_mutex_unlock (*lock);
   return val;

--- a/m-bitset.h
+++ b/m-bitset.h
@@ -81,7 +81,7 @@ typedef struct m_bitset_it_s {
 } m_bitset_it_t[1];
 
 /* Initialize a bitset (CONSTRUCTOR) */
-static inline void
+M_INLINE void
 m_bitset_init(m_bitset_t t)
 {
   M_ASSERT (t != NULL);
@@ -93,7 +93,7 @@ m_bitset_init(m_bitset_t t)
 }
 
 /* Clean a bitset */
-static inline void
+M_INLINE void
 m_bitset_reset(m_bitset_t t)
 {
   M_B1TSET_CONTRACT(t);
@@ -101,7 +101,7 @@ m_bitset_reset(m_bitset_t t)
 }
 
 /* Clear a bitset (DESTRUCTOR) */
-static inline void
+M_INLINE void
 m_bitset_clear(m_bitset_t t)
 {
   m_bitset_reset(t);
@@ -114,7 +114,7 @@ m_bitset_clear(m_bitset_t t)
 }
 
 /* Set a bitset to another one */
-static inline void
+M_INLINE void
 m_bitset_set(m_bitset_t d, const m_bitset_t s)
 {
   M_B1TSET_CONTRACT(d);
@@ -141,7 +141,7 @@ m_bitset_set(m_bitset_t d, const m_bitset_t s)
 }
 
 /* Initialize & set a bitset to another one (CONSTRUCTOR) */
-static inline void
+M_INLINE void
 m_bitset_init_set(m_bitset_t d, const m_bitset_t s)
 {
   M_ASSERT (d != s);
@@ -150,7 +150,7 @@ m_bitset_init_set(m_bitset_t d, const m_bitset_t s)
 }
 
 /* Initialize & move a bitset (CONSTRUCTOR) from another one (DESTRUCTOR) */
-static inline void
+M_INLINE void
 m_bitset_init_move(m_bitset_t d, m_bitset_t s)
 {
   M_B1TSET_CONTRACT(s);
@@ -164,7 +164,7 @@ m_bitset_init_move(m_bitset_t d, m_bitset_t s)
 }
 
 /* Move a bitset from another one (DESTRUCTOR) */
-static inline void
+M_INLINE void
 m_bitset_move(m_bitset_t d, m_bitset_t s)
 {
   m_bitset_clear(d);
@@ -172,7 +172,7 @@ m_bitset_move(m_bitset_t d, m_bitset_t s)
 }
 
 /* Set the bit 'i' in the bitset to the value 'x' */
-static inline void
+M_INLINE void
 m_bitset_set_at(m_bitset_t v, size_t i, bool x)
 {
   M_B1TSET_CONTRACT(v);
@@ -187,7 +187,7 @@ m_bitset_set_at(m_bitset_t v, size_t i, bool x)
 }
 
 /* Flip the bit 'i' in the bitset */
-static inline void
+M_INLINE void
 m_bitset_flip_at(m_bitset_t v, size_t i)
 {
   M_B1TSET_CONTRACT(v);
@@ -200,7 +200,7 @@ m_bitset_flip_at(m_bitset_t v, size_t i)
 }
 
 /* Push back the boolean 'x' in the bitset (increasing the bitset) */
-static inline void
+M_INLINE void
 m_bitset_push_back (m_bitset_t v, bool x)
 {
   M_B1TSET_CONTRACT (v);
@@ -239,7 +239,7 @@ m_bitset_push_back (m_bitset_t v, bool x)
 }
 
 /* Resize the bitset to have exactly 'size' bits */
-static inline void
+M_INLINE void
 m_bitset_resize (m_bitset_t v, size_t size)
 {
   M_B1TSET_CONTRACT (v);
@@ -287,7 +287,7 @@ m_bitset_resize (m_bitset_t v, size_t size)
 }
 
 /* Reserve allocation in the bitset to accomodate at least 'size' bits without reallocation */
-static inline void
+M_INLINE void
 m_bitset_reserve (m_bitset_t v, size_t alloc)
 {
   M_B1TSET_CONTRACT (v);
@@ -319,7 +319,7 @@ m_bitset_reserve (m_bitset_t v, size_t alloc)
  * NOTE: Interface is a little bit different:
  * It doesn't return a pointer to the data, but the data itself.
  */
-static inline bool
+M_INLINE bool
 m_bitset_get(const m_bitset_t v, size_t i)
 {
   M_B1TSET_CONTRACT(v);
@@ -334,7 +334,7 @@ m_bitset_get(const m_bitset_t v, size_t i)
 #define m_bitset_cget m_bitset_get
 
 /* Pop back the last bit in the bitset */
-static inline void
+M_INLINE void
 m_bitset_pop_back(bool *dest, m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -354,7 +354,7 @@ m_bitset_pop_back(bool *dest, m_bitset_t v)
 }
 
 /* Return the front bit value in the bitset */
-static inline bool
+M_INLINE bool
 m_bitset_front(m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -363,7 +363,7 @@ m_bitset_front(m_bitset_t v)
 }
 
 /* Return the back bit value in the bitset */
-static inline bool
+M_INLINE bool
 m_bitset_back(m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -372,7 +372,7 @@ m_bitset_back(m_bitset_t v)
 }
 
 /* Test if the bitset is empty (no bits stored)*/
-static inline bool
+M_INLINE bool
 m_bitset_empty_p(m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -380,7 +380,7 @@ m_bitset_empty_p(m_bitset_t v)
 }
 
 /* Return the number of bits of the bitset */
-static inline size_t
+M_INLINE size_t
 m_bitset_size(m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -388,7 +388,7 @@ m_bitset_size(m_bitset_t v)
 }
 
 /* Return the capacity in limbs of the bitset */
-static inline size_t
+M_INLINE size_t
 m_bitset_capacity(m_bitset_t v)
 {
   M_B1TSET_CONTRACT (v);
@@ -396,7 +396,7 @@ m_bitset_capacity(m_bitset_t v)
 }
 
 /* Swap the bit at index i and j of the bitset */
-static inline void
+M_INLINE void
 m_bitset_swap_at (m_bitset_t v, size_t i, size_t j)
 {
   M_ASSERT_INDEX(i, v->size);
@@ -409,7 +409,7 @@ m_bitset_swap_at (m_bitset_t v, size_t i, size_t j)
 }
 
 /* Swap the bitsets */
-static inline void
+M_INLINE void
 m_bitset_swap (m_bitset_t v1, m_bitset_t v2)
 {
   M_B1TSET_CONTRACT (v1);
@@ -425,7 +425,7 @@ m_bitset_swap (m_bitset_t v1, m_bitset_t v2)
  * integrating the carry in the lowest position.
  * Return the new carry.
  */
-static inline m_b1tset_limb_ct
+M_INLINE m_b1tset_limb_ct
 m_b1tset_lshift(m_b1tset_limb_ct ptr[], size_t n, m_b1tset_limb_ct carry)
 {
   for(size_t i = 0; i < n; i++) {
@@ -440,7 +440,7 @@ m_b1tset_lshift(m_b1tset_limb_ct ptr[], size_t n, m_b1tset_limb_ct carry)
  * integrating the carry in the lowest position.
  * Return the new carry.
  */
-static inline m_b1tset_limb_ct
+M_INLINE m_b1tset_limb_ct
 m_b1tset_rshift(m_b1tset_limb_ct ptr[], size_t n, m_b1tset_limb_ct carry)
 {
   for(size_t i = n - 1; i < n; i--) {
@@ -453,7 +453,7 @@ m_b1tset_rshift(m_b1tset_limb_ct ptr[], size_t n, m_b1tset_limb_ct carry)
 
 /* Insert a new bit at position 'key' of value 'value' in the bitset 'set'
   shifting the set accordingly */
-static inline void
+M_INLINE void
 m_bitset_push_at(m_bitset_t set, size_t key, bool value)
 {
   M_B1TSET_CONTRACT (set);
@@ -481,7 +481,7 @@ m_bitset_push_at(m_bitset_t set, size_t key, bool value)
 
 /* Pop a new bit at position 'key' in the bitset 
  * and return in *dest its value if *dest exists */
-static inline void
+M_INLINE void
 m_bitset_pop_at(bool *dest, m_bitset_t set, size_t key)
 {
   M_B1TSET_CONTRACT (set);
@@ -507,7 +507,7 @@ m_bitset_pop_at(bool *dest, m_bitset_t set, size_t key)
 }
 
 /* Test if two bitsets are equal */
-static inline bool
+M_INLINE bool
 m_bitset_equal_p (const m_bitset_t set1, const m_bitset_t set2)
 {
   M_B1TSET_CONTRACT (set1);
@@ -524,7 +524,7 @@ m_bitset_equal_p (const m_bitset_t set1, const m_bitset_t set2)
 }
 
 /* Initialize an iterator to the first bit of the biset */
-static inline void
+M_INLINE void
 m_bitset_it(m_bitset_it_t it, m_bitset_t set)
 {
    M_B1TSET_CONTRACT (set);
@@ -533,7 +533,7 @@ m_bitset_it(m_bitset_it_t it, m_bitset_t set)
 }
 
 /* Initialize an iterator to reference the same bit as the given one*/
-static inline void
+M_INLINE void
 m_bitset_it_set(m_bitset_it_t it, const m_bitset_it_t itorg)
 {
   M_ASSERT (it != NULL && itorg != NULL);
@@ -542,7 +542,7 @@ m_bitset_it_set(m_bitset_it_t it, const m_bitset_it_t itorg)
 }
 
 /* Initialize an iterator to reference the last bit of the bitset*/
-static inline void
+M_INLINE void
 m_bitset_it_last(m_bitset_it_t it, m_bitset_t set)
 {
    M_B1TSET_CONTRACT (set);
@@ -551,7 +551,7 @@ m_bitset_it_last(m_bitset_it_t it, m_bitset_t set)
 }
 
 /* Initialize an iterator to reference no valid bit of the bitset*/
-static inline void
+M_INLINE void
 m_bitset_it_end(m_bitset_it_t it, m_bitset_t set)
 {
    M_B1TSET_CONTRACT (set);
@@ -560,7 +560,7 @@ m_bitset_it_end(m_bitset_it_t it, m_bitset_t set)
 }
 
 /* Test if an iterator references no valid bit of the bitset anymore */
-static inline bool
+M_INLINE bool
 m_bitset_end_p(const m_bitset_it_t it)
 {
   M_ASSERT (it != NULL && it->set != NULL);
@@ -568,7 +568,7 @@ m_bitset_end_p(const m_bitset_it_t it)
 }
 
 /* Test if an iterator references the last (or end) bit of the bitset anymore */
-static inline bool
+M_INLINE bool
 m_bitset_last_p(const m_bitset_it_t it)
 {
   M_ASSERT (it != NULL && it->set != NULL);
@@ -578,7 +578,7 @@ m_bitset_last_p(const m_bitset_it_t it)
 }
 
 /* Test if both iterators reference the same bit */
-static inline bool
+M_INLINE bool
 m_bitset_it_equal_p(const m_bitset_it_t it1, const m_bitset_it_t it2)
 {
   M_ASSERT (it1 != NULL && it2 != NULL);
@@ -586,7 +586,7 @@ m_bitset_it_equal_p(const m_bitset_it_t it1, const m_bitset_it_t it2)
 }
 
 /* Move the iterator to the next bit */
-static inline void
+M_INLINE void
 m_bitset_next(m_bitset_it_t it)
 {
   M_ASSERT (it != NULL && it->set != NULL);
@@ -594,7 +594,7 @@ m_bitset_next(m_bitset_it_t it)
 }
 
 /* Move the iterator to the previous bit */
-static inline void
+M_INLINE void
 m_bitset_previous(m_bitset_it_t it)
 {
   M_ASSERT (it != NULL && it->set != NULL);
@@ -605,7 +605,7 @@ m_bitset_previous(m_bitset_it_t it)
 
 /* Return a pointer to the bit referenced by the iterator 
  * Only one reference is possible at a time per iterator */
-static inline const bool *
+M_INLINE const bool *
 m_bitset_cref(m_bitset_it_t it)
 {
   M_ASSERT (it != NULL && it->set != NULL);
@@ -614,7 +614,7 @@ m_bitset_cref(m_bitset_it_t it)
 }
 
 /* Output the bitset as a formatted text in a FILE */
-static inline void
+M_INLINE void
 m_bitset_out_str(FILE *file, const m_bitset_t set)
 {
   M_B1TSET_CONTRACT (set);
@@ -629,7 +629,7 @@ m_bitset_out_str(FILE *file, const m_bitset_t set)
 }
 
 /* Input the bitset from a formatted text in a FILE */
-static inline bool
+M_INLINE bool
 m_bitset_in_str(m_bitset_t set, FILE *file)
 {
   M_B1TSET_CONTRACT (set);
@@ -648,7 +648,7 @@ m_bitset_in_str(m_bitset_t set, FILE *file)
 }
 
 /* Parse the bitset from a formatted text in a C string */
-static inline bool
+M_INLINE bool
 m_bitset_parse_str(m_bitset_t set, const char str[], const char **endptr)
 {
   M_B1TSET_CONTRACT (set);
@@ -672,7 +672,7 @@ m_bitset_parse_str(m_bitset_t set, const char str[], const char **endptr)
 }
 
 /* Set the bitset from a formatted text in a C string */
-static inline bool
+M_INLINE bool
 m_bitset_set_str(m_bitset_t dest, const char str[])
 {
   return m_bitset_parse_str(dest, str, NULL);
@@ -680,7 +680,7 @@ m_bitset_set_str(m_bitset_t dest, const char str[])
 
 /* Perform an AND operation between the bitsets,
  * up to the minimum size of both bitsets */
-static inline void
+M_INLINE void
 m_bitset_and(m_bitset_t dest, const m_bitset_t src)
 {
   M_B1TSET_CONTRACT(dest);
@@ -696,7 +696,7 @@ m_bitset_and(m_bitset_t dest, const m_bitset_t src)
 
 /* Perform an OR operation between the bitsets,
  * up to the minimum size of both bitsets */
-static inline void
+M_INLINE void
 m_bitset_or(m_bitset_t dest, const m_bitset_t src)
 {
   M_B1TSET_CONTRACT(dest);
@@ -712,7 +712,7 @@ m_bitset_or(m_bitset_t dest, const m_bitset_t src)
 
 /* Perform an XOR operation between the bitsets,
  * up to the minimum size of both bitsets */
-static inline void
+M_INLINE void
 m_bitset_xor(m_bitset_t dest, const m_bitset_t src)
 {
   M_B1TSET_CONTRACT(dest);
@@ -733,7 +733,7 @@ m_bitset_xor(m_bitset_t dest, const m_bitset_t src)
 }
 
 /* Perform a NOT operation of the bitset */
-static inline void
+M_INLINE void
 m_bitset_not(m_bitset_t dest)
 {
   M_B1TSET_CONTRACT(dest);
@@ -751,7 +751,7 @@ m_bitset_not(m_bitset_t dest)
 }
 
 /* Copute a hash of the bitset */
-static inline size_t
+M_INLINE size_t
 m_bitset_hash(const m_bitset_t set)
 {
   M_B1TSET_CONTRACT(set);
@@ -764,7 +764,7 @@ m_bitset_hash(const m_bitset_t set)
 }
 
 /* Count the number of leading zero */
-static inline size_t
+M_INLINE size_t
 m_bitset_clz(const m_bitset_t set)
 {
   M_B1TSET_CONTRACT(set);
@@ -792,7 +792,7 @@ m_bitset_clz(const m_bitset_t set)
 }
 
 /* Count the number of trailing zero */
-static inline size_t
+M_INLINE size_t
 m_bitset_ctz(const m_bitset_t set)
 {
   M_B1TSET_CONTRACT(set);
@@ -819,14 +819,14 @@ m_bitset_ctz(const m_bitset_t set)
 
 // For GCC or CLANG or ICC
 #if defined(__GNUC__)
-static inline size_t m_b1tset_popcount64(m_b1tset_limb_ct limb)
+M_INLINE size_t m_b1tset_popcount64(m_b1tset_limb_ct limb)
 {
   return (size_t) __builtin_popcountll(limb);
 }
 #else
 // MSVC __popcnt64 may not exist on the target architecture (no emulation layer)
 // Use emulation layer: https://en.wikipedia.org/wiki/Hamming_weight
-static inline size_t m_b1tset_popcount64(m_b1tset_limb_ct limb)
+M_INLINE size_t m_b1tset_popcount64(m_b1tset_limb_ct limb)
 {
   limb = limb - ((limb >> 1) & 0x5555555555555555ULL);
   limb = (limb & 0x3333333333333333ULL) + ((limb >> 2) & 0x3333333333333333ULL);
@@ -836,7 +836,7 @@ static inline size_t m_b1tset_popcount64(m_b1tset_limb_ct limb)
 #endif
 
 /* Count the number of 1 */
-static inline size_t
+M_INLINE size_t
 m_bitset_popcount(const m_bitset_t set)
 {
   M_B1TSET_CONTRACT(set);
@@ -962,7 +962,7 @@ M_BEGIN_PROTECTED_CODE
 
 /* Output to a m_string_t 'str' the formatted text representation of the bitset 'set'
    or append it to the strinf (append=true) */
-static inline void
+M_INLINE void
 m_bitset_get_str(m_string_t str, const m_bitset_t set, bool append)
 {
   M_B1TSET_CONTRACT (set);

--- a/m-bptree.h
+++ b/m-bptree.h
@@ -406,7 +406,7 @@
                                                                               \
   /* Allocate a new node */                                                   \
   /* TODO: Can be specialized to alloc for leaf or for non leaf */            \
-  static inline node_t M_F(name, _new_node)(void)                             \
+  M_INLINE node_t M_F(name, _new_node)(void)                                  \
   {                                                                           \
     M_STATIC_ASSERT(N >= 2, M_LIB_ILLEGAL_PARAM,                              \
           "Number of items per node shall be >= 2.");                         \
@@ -420,14 +420,14 @@
     return n;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _init)(tree_t b)                               \
+  M_INLINE void M_F(name, _init)(tree_t b)                                    \
   {                                                                           \
     b->root = M_F(name, _new_node)();                                         \
     b->size = 0;                                                              \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
   }                                                                           \
                                                                               \
-  static inline bool M_F(name, _is_leaf)(const node_t n)                      \
+  M_INLINE bool M_F(name, _is_leaf)(const node_t n)                           \
   {                                                                           \
     /* We consider the empty node as a leaf */                                \
     /* Only the root node can be empty */                                     \
@@ -435,7 +435,7 @@
   }                                                                           \
                                                                               \
   /* Return the number of keys of the node */                                 \
-  static inline int M_F(name, _get_num)(const node_t n)                       \
+  M_INLINE int M_F(name, _get_num)(const node_t n)                            \
   {                                                                           \
     int num = n->num;                                                         \
     num = num < 0 ? -num : num;                                               \
@@ -443,7 +443,7 @@
     return num;                                                               \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _reset)(tree_t b)                              \
+  M_INLINE void M_F(name, _reset)(tree_t b)                                   \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     node_t next, n = b->root;                                                 \
@@ -486,7 +486,7 @@
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _clear)(tree_t b)                              \
+  M_INLINE void M_F(name, _clear)(tree_t b)                                   \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     M_F(name, _reset)(b);                                                     \
@@ -496,7 +496,7 @@
   }                                                                           \
                                                                               \
   /* Copy recursively the node 'o' of root node 'root' */                     \
-  static inline node_t M_F(name, _copy_node)(const node_t o, const node_t root) \
+  M_INLINE node_t M_F(name, _copy_node)(const node_t o, const node_t root)    \
   {                                                                           \
     node_t n = M_F(name, _new_node)();                                        \
     /* Set default number of keys and type to copy */                         \
@@ -542,7 +542,7 @@
     return n;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _init_set)(tree_t b, const tree_t o)           \
+  M_INLINE void M_F(name, _init_set)(tree_t b, const tree_t o)                \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, o);                             \
     M_ASSERT (b != NULL);                                                     \
@@ -552,7 +552,7 @@
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _set)(tree_t b, const tree_t o)                \
+  M_INLINE void M_F(name, _set)(tree_t b, const tree_t o)                     \
   {                                                                           \
     /* NOTE: We could reuse the already allocated nodes of 'b'.               \
        Not sure if it worth the effort */                                     \
@@ -560,20 +560,20 @@
     M_F(name, _init_set)(b, o);                                               \
   }                                                                           \
                                                                               \
-  static inline bool M_F(name, _empty_p)(const tree_t b)                      \
+  M_INLINE bool M_F(name, _empty_p)(const tree_t b)                           \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     /* root shall be an empty leaf */                                         \
     return b->size == 0;                                                      \
   }                                                                           \
                                                                               \
-  static inline size_t M_F(name, _size)(const tree_t b)                       \
+  M_INLINE size_t M_F(name, _size)(const tree_t b)                            \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     return b->size;                                                           \
   }                                                                           \
                                                                               \
-  static inline node_t M_F(name, _search_for_leaf)(pit_t pit, const tree_t b, key_t const key) \
+  M_INLINE node_t M_F(name, _search_for_leaf)(pit_t pit, const tree_t b, key_t const key) \
   {                                                                           \
     node_t n = b->root;                                                       \
     int np = 0;                                                               \
@@ -602,7 +602,7 @@
     return n;                                                                 \
   }                                                                           \
                                                                               \
-  static inline value_t *M_F(name, _get)(const tree_t b, key_t const key)     \
+  M_INLINE value_t *M_F(name, _get)(const tree_t b, key_t const key)          \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     pit_t pit;                                                                \
@@ -622,12 +622,12 @@
     return NULL;                                                              \
   }                                                                           \
                                                                               \
-  static inline value_t const *M_F(name, _cget)(const tree_t b, key_t const key) \
+  M_INLINE value_t const *M_F(name, _cget)(const tree_t b, key_t const key)   \
   {                                                                           \
     return M_CONST_CAST(value_t, M_F(name, _get)(b, key));                    \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _search_and_insert_in_leaf)(node_t n, key_t const key             \
                                         M_IF(isMap)( M_DEFERRED_COMMA value_t const value,) ) \
   {                                                                           \
@@ -659,7 +659,7 @@
     return i;                                                                 \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _search_and_insert_in_node)(node_t n, node_t l, key_t key)        \
   {                                                                           \
     M_ASSERT (!M_F(name, _is_leaf)(n));                                       \
@@ -682,7 +682,7 @@
     return i;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_IF(isMap)(M_F(name, _set_at),M_F(name,_push))(tree_t b, key_t const key   \
                                                   M_IF(isMap)(M_DEFERRED_COMMA value_t const value,)) \
   {                                                                           \
@@ -772,7 +772,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline value_t *M_F(name, _safe_get)(tree_t b, key_t const key)      \
+  M_INLINE value_t *M_F(name, _safe_get)(tree_t b, key_t const key)           \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     /* Not optimized implementation */                                        \
@@ -791,7 +791,7 @@
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _search_and_remove_in_leaf)(node_t n, key_t const key)            \
   {                                                                           \
     M_ASSERT(M_F(name, _is_leaf)(n));                                         \
@@ -811,7 +811,7 @@
     return -1; /* Not found */                                                \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _left_shift)(node_t parent, int k)             \
+  M_INLINE void M_F(name, _left_shift)(node_t parent, int k)                  \
   {                                                                           \
     M_ASSERT (parent != NULL && !M_F(name, _is_leaf)(parent));                \
     M_ASSERT (0 <= k && k < M_F(name, _get_num)(parent));                     \
@@ -846,7 +846,7 @@
     M_ASSERT (left->num != 0);                                                \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _right_shift)(node_t parent, int k)            \
+  M_INLINE void M_F(name, _right_shift)(node_t parent, int k)                 \
   {                                                                           \
     M_ASSERT (parent != NULL && !M_F(name, _is_leaf)(parent));                \
     M_ASSERT (0 <= k && k < M_F(name, _get_num)(parent));                     \
@@ -880,7 +880,7 @@
     M_ASSERT (left->num != 0);                                                \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _merge_node)(node_t parent, int k, bool leaf)  \
+  M_INLINE void M_F(name, _merge_node)(node_t parent, int k, bool leaf)       \
   {                                                                           \
     M_ASSERT (parent != NULL && !M_F(name, _is_leaf)(parent));                \
     M_ASSERT (0 <= k && k < M_F(name, _get_num(parent)));                     \
@@ -915,7 +915,7 @@
                                                                               \
   /* We can also cache the index when we descend the tree.                    \
      TODO: Bench if this is worth the effort.*/                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _search_for_node)(node_t parent, node_t child)                    \
   {                                                                           \
     M_ASSERT (!M_F(name, _is_leaf)(parent));                                  \
@@ -928,7 +928,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool M_F(name, _erase)(tree_t b, key_t const key)             \
+  M_INLINE bool M_F(name, _erase)(tree_t b, key_t const key)                  \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
     pit_t pit;                                                                \
@@ -984,7 +984,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool M_F(name, _pop_at)(value_t *ptr, tree_t b, key_t const key) \
+  M_INLINE bool M_F(name, _pop_at)(value_t *ptr, tree_t b, key_t const key)   \
   {                                                                           \
     if (ptr != NULL) {                                                        \
       value_t *ref = M_F(name, _get)(b, key);                                 \
@@ -996,7 +996,7 @@
     return M_F(name, _erase)(b, key);                                         \
   }                                                                           \
                                                                               \
-  static inline value_t *                                                     \
+  M_INLINE value_t *                                                          \
   M_F(name, _min)(const tree_t b)                                             \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1009,7 +1009,7 @@
     return &n->M_IF(isMap)(kind.value, key)[0];                               \
   }                                                                           \
                                                                               \
-  static inline value_t *                                                     \
+  M_INLINE value_t *                                                          \
   M_F(name, _max)(const tree_t b)                                             \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1022,19 +1022,19 @@
     return &n->M_IF(isMap)(kind.value, key)[-n->num-1];                       \
   }                                                                           \
                                                                               \
-  static inline value_t const *                                               \
+  M_INLINE value_t const *                                                    \
   M_F(name, _cmin)(const tree_t tree)                                         \
   {                                                                           \
     return M_CONST_CAST(value_t, M_F(name, _min)(tree));                      \
   }                                                                           \
                                                                               \
-  static inline value_t const *                                               \
+  M_INLINE value_t const *                                                    \
   M_F(name, _cmax)(const tree_t tree)                                         \
   {                                                                           \
     return M_CONST_CAST(value_t, M_F(name, _max)(tree));                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(tree_t b, tree_t ref)                                 \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, ref);                           \
@@ -1045,7 +1045,7 @@
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(tree_t b, tree_t ref)                                      \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1056,7 +1056,7 @@
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(tree_t tree1, tree_t tree2)                                \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, tree1);                         \
@@ -1070,7 +1070,7 @@
 /* Define iterator functions. */
 #define M_BPTR33_DEF_IT(name, N, key_t, key_oplist, value_t, value_oplist, isMap, isMulti, tree_t, node_t, pit_t, it_t, subtype_t) \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const tree_t b)                                     \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1084,7 +1084,7 @@
     it->idx  = 0;                                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, const tree_t b)                                 \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1098,7 +1098,7 @@
     it->idx  = -n->num;                                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t itd, const it_t its)                                \
   {                                                                           \
     M_ASSERT (itd != NULL && its != NULL);                                    \
@@ -1106,7 +1106,7 @@
     itd->idx  = its->idx;                                                     \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(it_t it)                                                  \
   {                                                                           \
     M_ASSERT (it != NULL && it->node != NULL);                                \
@@ -1114,13 +1114,13 @@
     return it->node->next ==NULL && it->idx >= -it->node->num;                \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1, const it_t it2)                      \
   {                                                                           \
     return it1->node == it2->node && it1->idx == it2->idx;                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT (it != NULL && it->node != NULL);                                \
@@ -1132,7 +1132,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline subtype_t *                                                   \
+  M_INLINE subtype_t *                                                        \
   M_F(name, _ref)(it_t it)                                                    \
   {                                                                           \
     M_ASSERT (it != NULL && it->node != NULL);                                \
@@ -1147,14 +1147,14 @@
                                                                         );    \
   }                                                                           \
                                                                               \
-  static inline subtype_t const *                                             \
+  M_INLINE subtype_t const *                                                  \
   M_F(name, _cref)(it_t it)                                                   \
   {                                                                           \
     return M_CONST_CAST(subtype_t, M_F(name, _ref)(it));                      \
   }                                                                           \
                                                                               \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_from)(it_t it, const tree_t b, key_t const key)               \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, b);                             \
@@ -1175,7 +1175,7 @@
     it->idx  = i;                                                             \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_until_p)(it_t it, key_t const key)                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1185,7 +1185,7 @@
     return (cmp >= 0);                                                        \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_while_p)(it_t it, key_t const key)                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1200,7 +1200,7 @@
 #define M_BPTR33_DEF_EXT(name, N, key_t, key_oplist, value_t, value_oplist, isMap, isMulti, tree_t, node_t, pit_t, it_t, subtype_t) \
                                                                               \
   M_IF_METHOD_BOTH(EQUAL, key_oplist, value_oplist)(                          \
-  static inline bool M_F(name,_equal_p)(const tree_t t1, const tree_t t2) {   \
+  M_INLINE bool M_F(name,_equal_p)(const tree_t t1, const tree_t t2) {        \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t2);                            \
     if (t1->size != t2->size) return false;                                   \
@@ -1236,7 +1236,7 @@
   , /* NO EQUAL METHOD */ )                                                   \
                                                                               \
   M_IF_METHOD_BOTH(HASH, key_oplist, value_oplist)(                           \
-  static inline size_t M_F(name,_hash)(const tree_t t1) {                     \
+  M_INLINE size_t M_F(name,_hash)(const tree_t t1) {                          \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
     M_HASH_DECL(hash);                                                        \
     /* NOTE: We can't compute the hash directly for the same reason           \
@@ -1258,7 +1258,7 @@
   , /* NO HASH METHOD */ )                                                    \
                                                                               \
   M_IF_METHOD_BOTH(GET_STR, key_oplist, value_oplist)(                        \
-  static inline void M_F(name, _get_str)(m_string_t str,                      \
+  M_INLINE void M_F(name, _get_str)(m_string_t str,                           \
                                          const tree_t t1, bool append) {      \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
     M_ASSERT(str != NULL);                                                    \
@@ -1286,7 +1286,7 @@
   , /* NO GET_STR */ )                                                        \
                                                                               \
   M_IF_METHOD_BOTH(OUT_STR, key_oplist, value_oplist)(                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, tree_t const t1)                            \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
@@ -1314,7 +1314,7 @@
   , /* no out_str */ )                                                        \
                                                                               \
   M_IF_METHOD_BOTH(PARSE_STR, key_oplist, value_oplist)(                      \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(tree_t t1, const char str[], const char **endp)       \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
@@ -1356,7 +1356,7 @@
   , /* no parse_str */ )                                                      \
                                                                               \
   M_IF_METHOD_BOTH(IN_STR, key_oplist, value_oplist)(                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(tree_t t1, FILE *file)                                   \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
@@ -1394,7 +1394,7 @@
   , /* no in_str */ )                                                         \
                                                                               \
   M_IF_METHOD_BOTH(OUT_SERIAL, key_oplist, value_oplist)(                     \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, tree_t const t1)                 \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \
@@ -1438,7 +1438,7 @@
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD_BOTH(IN_SERIAL, key_oplist, value_oplist)(                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(tree_t t1, m_serial_read_t f)                         \
   {                                                                           \
     M_BPTR33_CONTRACT(N, isMulti, key_oplist, t1);                            \

--- a/m-buffer.h
+++ b/m-buffer.h
@@ -152,7 +152,7 @@ typedef union m_buff3r_number_s {
 #endif
 } m_buff3r_number_ct[1];
 
-static inline void
+M_INLINE void
 m_buff3r_number_init(m_buff3r_number_ct n, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -161,7 +161,7 @@ m_buff3r_number_init(m_buff3r_number_ct n, unsigned int policy)
     n->u = 0UL;
 }
 
-static inline unsigned int
+M_INLINE unsigned int
 m_buff3r_number_load(m_buff3r_number_ct n, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -172,7 +172,7 @@ m_buff3r_number_load(m_buff3r_number_ct n, unsigned int policy)
     return n->u;
 }
 
-static inline void
+M_INLINE void
 m_buff3r_number_store(m_buff3r_number_ct n, unsigned int v, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -182,7 +182,7 @@ m_buff3r_number_store(m_buff3r_number_ct n, unsigned int v, unsigned int policy)
     n->u = v;
 }
 
-static inline void
+M_INLINE void
 m_buff3r_number_set(m_buff3r_number_ct n, m_buff3r_number_ct v, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -192,7 +192,7 @@ m_buff3r_number_set(m_buff3r_number_ct n, m_buff3r_number_ct v, unsigned int pol
     n->u = v->u;
 }
 
-static inline unsigned int
+M_INLINE unsigned int
 m_buff3r_number_inc(m_buff3r_number_ct n, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -201,7 +201,7 @@ m_buff3r_number_inc(m_buff3r_number_ct n, unsigned int policy)
     return n->u ++;
 }
 
-static inline unsigned int
+M_INLINE unsigned int
 m_buff3r_number_dec(m_buff3r_number_ct n, unsigned int policy)
 {
   if (!M_BUFF3R_POLICY_P(policy, M_BUFFER_THREAD_UNSAFE))
@@ -300,7 +300,7 @@ m_buff3r_number_dec(m_buff3r_number_ct n, unsigned int policy)
 /* Define the core functionnalities of a buffer */
 #define M_BUFF3R_DEF_CORE(name, type, m_size, policy, oplist, buffer_t)       \
                                                                               \
-static inline void                                                            \
+M_INLINE void                                                                 \
 M_F(name, _init)(buffer_t v, size_t size)                                     \
 {                                                                             \
   M_BUFF3R_IF_CTE_SIZE(m_size)(M_ASSERT(size == m_size), v->size = size);     \
@@ -334,14 +334,14 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
 }                                                                             \
                                                                               \
  M_BUFF3R_IF_CTE_SIZE(m_size)(                                                \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_C3(m_buff3r_,name,_init)(buffer_t v)                                       \
  {                                                                            \
    M_F(name, _init)(v, m_size);                                               \
  }                                                                            \
  , )                                                                          \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_C3(m_buff3r_,name,_clear_obj)(buffer_t v)                                  \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -365,7 +365,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
  }                                                                            \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_F(name, _clear)(buffer_t v)                                                \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -383,7 +383,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    }                                                                          \
  }                                                                            \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_F(name, _reset)(buffer_t v)                                                \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -406,13 +406,13 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
  }                                                                            \
                                                                               \
- static inline void M_ATTR_DEPRECATED                                         \
+ M_INLINE void M_ATTR_DEPRECATED                                              \
  M_F(name, _clean)(buffer_t v)                                                \
  {                                                                            \
    M_F(name,_reset)(v);                                                       \
  }                                                                            \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_F(name, _init_set)(buffer_t dest, const buffer_t src)                      \
  {                                                                            \
    /* unconst 'src', so that we can lock it (semantically it is const) */     \
@@ -456,7 +456,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    M_BUFF3R_CONTRACT(dest, m_size);                                           \
  }                                                                            \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_F(name, _set)(buffer_t dest, const buffer_t src)                           \
  {                                                                            \
    /* unconst 'src', so that we can lock it (semantically it is const) */     \
@@ -526,7 +526,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    M_BUFF3R_CONTRACT(dest, m_size);                                           \
  }                                                                            \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _empty_p)(buffer_t v)                                              \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -540,7 +540,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
      return m_buff3r_number_load (v->number[0], policy) == 0;                 \
  }                                                                            \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _full_p)(buffer_t v)                                               \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -548,14 +548,14 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
      == M_BUFF3R_SIZE(m_size);                                                \
  }                                                                            \
                                                                               \
- static inline size_t                                                         \
+ M_INLINE size_t                                                              \
  M_F(name, _size)(buffer_t v)                                                 \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
    return m_buff3r_number_load (v->number[0], policy);                        \
  }                                                                            \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _push_blocking)(buffer_t v, type const data, bool blocking)        \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -635,7 +635,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
    return true;                                                               \
  }                                                                            \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _pop_blocking)(type *data, buffer_t v, bool blocking)              \
  {                                                                            \
    M_BUFF3R_CONTRACT(v,m_size);                                               \
@@ -706,34 +706,34 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
  }                                                                            \
                                                                               \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _push)(buffer_t v, type const data)                                \
  {                                                                            \
    return M_F(name, _push_blocking)(v, data,                                  \
                              !M_BUFF3R_POLICY_P((policy), M_BUFFER_UNBLOCKING_PUSH)); \
  }                                                                            \
                                                                               \
- static inline bool                                                           \
+ M_INLINE bool                                                                \
  M_F(name, _pop)(type *data, buffer_t v)                                      \
  {                                                                            \
    return M_F(name, _pop_blocking)(data, v,                                   \
                             !M_BUFF3R_POLICY_P((policy), M_BUFFER_UNBLOCKING_POP)); \
  }                                                                            \
                                                                               \
- static inline size_t                                                         \
+ M_INLINE size_t                                                              \
  M_F(name, _overwrite)(const buffer_t v)                                      \
  {                                                                            \
    return v->overwrite;                                                       \
  }                                                                            \
                                                                               \
- static inline size_t                                                         \
+ M_INLINE size_t                                                              \
  M_F(name, _capacity)(const buffer_t v)                                       \
  {                                                                            \
    (void) v; /* may be unused */                                              \
    return M_BUFF3R_SIZE(m_size);                                              \
  }                                                                            \
                                                                               \
- static inline void                                                           \
+ M_INLINE void                                                                \
  M_F(name, _pop_release)(buffer_t v)                                          \
  {                                                                            \
    /* Decrement the effective number of elements in the buffer */             \
@@ -833,7 +833,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
 
 /* Define the core functionnalities of a MPMC queue */
 #define M_QU3UE_MPMC_DEF_CORE(name, type, policy, oplist, buffer_t)           \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _push)(buffer_t table, type const x)                              \
   {                                                                           \
     M_QU3UE_MPMC_CONTRACT(table);                                             \
@@ -867,7 +867,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _pop)(type *ptr, buffer_t table)                                  \
   {                                                                           \
     M_QU3UE_MPMC_CONTRACT(table);                                             \
@@ -896,7 +896,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(buffer_t buffer, size_t size)                              \
   {                                                                           \
     M_ASSERT (buffer != NULL);                                                \
@@ -920,7 +920,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     M_QU3UE_MPMC_CONTRACT(buffer);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(buffer_t buffer)                                          \
   {                                                                           \
     M_QU3UE_MPMC_CONTRACT(buffer);                                            \
@@ -945,7 +945,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     buffer->size = 3;                                                         \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(buffer_t table)                                            \
   {                                                                           \
     M_QU3UE_MPMC_CONTRACT(table);                                             \
@@ -964,20 +964,20 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return iP-iC;                                                             \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity)(buffer_t v)                                            \
   {                                                                           \
     M_QU3UE_MPMC_CONTRACT(v);                                                 \
     return v->size;                                                           \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(buffer_t v)                                             \
   {                                                                           \
     return M_F(name, _size) (v) == 0;                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _full_p)(buffer_t v)                                              \
   {                                                                           \
     return M_F(name, _size)(v) >= v->size;                                    \
@@ -1060,7 +1060,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
 /* Define the core functionnalities of a SPSC queue */
 #define M_QU3UE_SPSC_DEF_CORE(name, type, policy, oplist, buffer_t)           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _push)(buffer_t table, type const x)                              \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1081,7 +1081,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _push_move)(buffer_t table, type *x)                              \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1102,7 +1102,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _pop)(type *ptr, buffer_t table)                                  \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1124,7 +1124,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline unsigned                                                      \
+  M_INLINE unsigned                                                           \
   M_F(name, _push_bulk)(buffer_t table, unsigned n, type const x[])           \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1150,7 +1150,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return max;                                                               \
   }                                                                           \
                                                                               \
-  static inline unsigned                                                      \
+  M_INLINE unsigned                                                           \
   M_F(name, _pop_bulk)(unsigned int n, type ptr[], buffer_t table)            \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1176,7 +1176,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return max;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_force)(buffer_t table, type const x)                        \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1199,7 +1199,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(buffer_t table)                                            \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(table);                                             \
@@ -1220,25 +1220,25 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     return w-r;                                                               \
   }                                                                           \
                                                                               \
- static inline size_t                                                         \
+ M_INLINE size_t                                                              \
  M_F(name, _capacity)(buffer_t v)                                             \
  {                                                                            \
    return v->size;                                                            \
  }                                                                            \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(buffer_t v)                                             \
   {                                                                           \
     return M_F(name, _size) (v) == 0;                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _full_p)(buffer_t v)                                              \
   {                                                                           \
     return M_F(name, _size)(v) >= v->size;                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(buffer_t buffer, size_t size)                              \
   {                                                                           \
     M_ASSERT (buffer != NULL);                                                \
@@ -1261,7 +1261,7 @@ M_F(name, _init)(buffer_t v, size_t size)                                     \
     M_QU3UE_SPSC_CONTRACT(buffer);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(buffer_t buffer)                                          \
   {                                                                           \
     M_QU3UE_SPSC_CONTRACT(buffer);                                            \

--- a/m-c-mempool.h
+++ b/m-c-mempool.h
@@ -53,13 +53,13 @@ M_BEGIN_PROTECTED_CODE
                                                                               \
   typedef struct M_F(name, _slist_node_s) *M_F(name, _slist_ct)[1];           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _slist_init)(M_F(name, _slist_ct) list)                           \
   {                                                                           \
     *list = NULL;                                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _slist_push)(M_F(name, _slist_ct) list,                           \
                         M_F(name, _slist_node_ct) *node)                      \
   {                                                                           \
@@ -67,7 +67,7 @@ M_BEGIN_PROTECTED_CODE
     *list = node;                                                             \
   }                                                                           \
                                                                               \
-  static inline M_F(name, _slist_node_ct) *                                   \
+  M_INLINE M_F(name, _slist_node_ct) *                                        \
   M_F(name, _slist_pop)(M_F(name, _slist_ct) list)                            \
   {                                                                           \
     M_ASSERT (*list != NULL);                                                 \
@@ -77,13 +77,13 @@ M_BEGIN_PROTECTED_CODE
     return node;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _slist_empty_p)(M_F(name, _slist_ct) list)                        \
   {                                                                           \
     return *list == NULL;                                                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _slist_move)(M_F(name, _slist_ct) list,                           \
                          M_F(name, _slist_ct) src)                            \
   {                                                                           \
@@ -91,7 +91,7 @@ M_BEGIN_PROTECTED_CODE
     *src  = NULL;                                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _slist_clear)(M_F(name, _slist_ct) list)                          \
   {                                                                           \
     M_F(name, _slist_node_ct) *it = *list, *next;                             \
@@ -139,7 +139,7 @@ M_BEGIN_PROTECTED_CODE
     M_F(name, _lf_node_t)            nil;                                     \
   } M_F(name, _lflist_ct)[1];                                                 \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _lflist_init)(M_F(name, _lflist_ct) list,                         \
                           M_F(name, _lf_node_t) *node)                        \
   {                                                                           \
@@ -148,13 +148,13 @@ M_BEGIN_PROTECTED_CODE
     atomic_store_explicit(&node->next, &list->nil, memory_order_relaxed);     \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _lflist_empty_p)(M_F(name, _lflist_ct) list)                      \
   {                                                                           \
     return atomic_load(&list->tail) == atomic_load(&list->head);              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _lflist_push)(M_F(name, _lflist_ct) list,                         \
                           M_F(name, _lf_node_t) *node, m_core_backoff_ct bkoff) \
   {                                                                           \
@@ -190,7 +190,7 @@ M_BEGIN_PROTECTED_CODE
                                             memory_order_relaxed);            \
   }                                                                           \
                                                                               \
-  static inline M_F(name, _lf_node_t) *                                       \
+  M_INLINE M_F(name, _lf_node_t) *                                            \
   M_F(name, _lflist_pop)(M_F(name, _lflist_ct) list, m_core_backoff_ct bkoff) \
   {                                                                           \
     M_F(name, _lf_node_t) *head;                                              \
@@ -241,7 +241,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* Dequeue a node if the node is old enough */                              \
-  static inline M_F(name, _lf_node_t) *                                       \
+  M_INLINE M_F(name, _lf_node_t) *                                            \
   M_F(name, _lflist_pop_if)(M_F(name, _lflist_ct) list,                       \
                             m_gc_ticket_ct age, m_core_backoff_ct bkoff)      \
   {                                                                           \
@@ -281,7 +281,7 @@ M_BEGIN_PROTECTED_CODE
    return head;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _lflist_clear)(M_F(name, _lflist_ct) list)                        \
   {                                                                           \
     m_core_backoff_ct bkoff;                                                  \
@@ -306,7 +306,7 @@ M_BEGIN_PROTECTED_CODE
    As such it is a non Lock-Free path. */
 #define M_CMEMP00L_DEF_SYSTEM_ALLOC(name, type_t)                             \
                                                                               \
-  static inline M_F(name, _lf_node_t) *                                       \
+  M_INLINE M_F(name, _lf_node_t) *                                            \
        M_F(name, _alloc_node)(unsigned int initial)                           \
   {                                                                           \
     M_F(name, _lf_node_t) * node;                                             \
@@ -394,14 +394,14 @@ M_BEGIN_PROTECTED_CODE
     M_CACHELINE_ALIGN(align1, M_F(name, _slist_ct), M_F(name, _slist_ct));    \
   } M_F(name, _lfmp_thread_ct);                                               \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _lfmp_thread_init)(M_F(name, _lfmp_thread_ct) *t)                 \
   {                                                                           \
     M_F(name, _slist_init)(t->free);                                          \
     M_F(name, _slist_init)(t->to_be_reclaimed);                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _lfmp_thread_clear)(M_F(name, _lfmp_thread_ct) *t)                \
   {                                                                           \
     M_ASSERT(M_F(name, _slist_empty_p)(t->to_be_reclaimed));                  \
@@ -423,7 +423,7 @@ M_BEGIN_PROTECTED_CODE
   } M_F(name, _t)[1];                                                         \
                                                                               \
   /* Garbage collect of the nodes of the mempool on sleep */                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_cmemp00l_,name,_gc_on_sleep)(m_gc_t gc_mem, m_cmemp00l_list_ct *data, \
          m_gc_tid_t id, m_gc_ticket_ct ticket, m_gc_ticket_ct min_ticket)     \
   {                                                                           \
@@ -458,7 +458,7 @@ M_BEGIN_PROTECTED_CODE
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(M_F(name, _t) mem, m_gc_t gc_mem,                          \
                    unsigned init_node_count, unsigned init_group_count)       \
   {                                                                           \
@@ -490,7 +490,7 @@ M_BEGIN_PROTECTED_CODE
     mem->gc_mem = gc_mem;                                                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(M_F(name, _t) mem)                                        \
   {                                                                           \
     const unsigned max_thread = mem->gc_mem->max_thread;                      \
@@ -506,7 +506,7 @@ M_BEGIN_PROTECTED_CODE
     /* TODO: Unregister from the GC? */                                       \
   }                                                                           \
                                                                               \
-  static inline type_t *                                                      \
+  M_INLINE type_t *                                                           \
   M_F(name, _new)(M_F(name, _t) mem, m_gc_tid_t id)                           \
   {                                                                           \
     M_F(name, _slist_node_ct) *snode;                                         \
@@ -533,7 +533,7 @@ M_BEGIN_PROTECTED_CODE
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _del)(M_F(name, _t) mem, type_t *d, m_gc_tid_t id)                \
   {                                                                           \
     M_F(name, _slist_node_ct) *snode;                                         \
@@ -579,7 +579,7 @@ typedef struct m_gc_s {
   m_cmemp00l_list_ct     *mempool_list;
 } m_gc_t[1];
 
-static inline void
+M_INLINE void
 m_gc_init(m_gc_t gc_mem, size_t max_thread)
 {
   M_ASSERT(gc_mem != NULL);
@@ -600,7 +600,7 @@ m_gc_init(m_gc_t gc_mem, size_t max_thread)
   gc_mem->mempool_list = NULL;
 }
 
-static inline void
+M_INLINE void
 m_gc_clear(m_gc_t gc_mem)
 {
   M_ASSERT(gc_mem != NULL && gc_mem->max_thread > 0);
@@ -613,7 +613,7 @@ m_gc_clear(m_gc_t gc_mem)
   m_genint_clear(gc_mem->thread_alloc);
 }
 
-static inline m_gc_tid_t
+M_INLINE m_gc_tid_t
 m_gc_attach_thread(m_gc_t gc_mem)
 {
   M_ASSERT(gc_mem != NULL && gc_mem->max_thread > 0);
@@ -622,7 +622,7 @@ m_gc_attach_thread(m_gc_t gc_mem)
   return M_ASSIGN_CAST(m_gc_tid_t, id);
 }
   
-static inline void
+M_INLINE void
 m_gc_detach_thread(m_gc_t gc_mem, m_gc_tid_t id)
 {
   M_ASSERT(gc_mem != NULL && gc_mem->max_thread > 0);
@@ -632,7 +632,7 @@ m_gc_detach_thread(m_gc_t gc_mem, m_gc_tid_t id)
   m_genint_push(gc_mem->thread_alloc, id);
 }
   
-static inline void
+M_INLINE void
 m_gc_awake(m_gc_t gc_mem, m_gc_tid_t id)
 {
   M_ASSERT(gc_mem != NULL && gc_mem->max_thread > 0);
@@ -643,7 +643,7 @@ m_gc_awake(m_gc_t gc_mem, m_gc_tid_t id)
   atomic_store(&gc_mem->thread_data[id].ticket, t);
 }
   
-static inline m_gc_ticket_ct
+M_INLINE m_gc_ticket_ct
 m_cmemp00l_gc_min_ticket(m_gc_t gc_mem)
 {
   m_gc_ticket_ct min = atomic_load(&gc_mem->thread_data[0].ticket);
@@ -654,7 +654,7 @@ m_cmemp00l_gc_min_ticket(m_gc_t gc_mem)
   return min;
 }
 
-static inline void
+M_INLINE void
 m_gc_sleep(m_gc_t gc_mem, m_gc_tid_t id)
 {
   /* Increase life time of the thread */
@@ -690,13 +690,13 @@ typedef struct m_vlapool_lfmp_thread_s {
   M_CACHELINE_ALIGN(align1, m_vlapool_slist_ct);
 } m_vlapool_lfmp_thread_ct;
 
-static inline void
+M_INLINE void
 m_vlapool_lfmp_thread_init(m_vlapool_lfmp_thread_ct *t)
 {
   m_vlapool_slist_init(t->to_be_reclaimed);
 }
 
-static inline void
+M_INLINE void
 m_vlapool_lfmp_thread_clear(m_vlapool_lfmp_thread_ct *t)
 {
   M_ASSERT(m_vlapool_slist_empty_p(t->to_be_reclaimed));
@@ -712,7 +712,7 @@ typedef struct m_vlapool_s {
 } m_vlapool_t[1];
 
 /* Garbage collect of the nodes of the vla mempool on sleep */
-static inline void
+M_INLINE void
 m_cmemp00l_vlapool_on_sleep(m_gc_t gc_mem, m_cmemp00l_list_ct *data,
                           m_gc_tid_t id, m_gc_ticket_ct ticket, m_gc_ticket_ct min_ticket)
 {
@@ -751,7 +751,7 @@ m_cmemp00l_vlapool_on_sleep(m_gc_t gc_mem, m_cmemp00l_list_ct *data,
   }
 }
 
-static inline void
+M_INLINE void
 m_vlapool_init(m_vlapool_t mem, m_gc_t gc_mem)
 {
   const size_t max_thread =  gc_mem->max_thread;
@@ -777,7 +777,7 @@ m_vlapool_init(m_vlapool_t mem, m_gc_t gc_mem)
   mem->gc_mem = gc_mem;
 }
 
-static inline void
+M_INLINE void
 m_vlapool_clear(m_vlapool_t mem)
 {
   const unsigned max_thread = mem->gc_mem->max_thread;
@@ -792,7 +792,7 @@ m_vlapool_clear(m_vlapool_t mem)
   /* TODO: Unregister from the GC? */
 }
 
-static inline void *
+M_INLINE void *
 m_vlapool_new(m_vlapool_t mem, m_gc_tid_t id, size_t size)
 {
   M_ASSERT(mem != NULL && mem->gc_mem != NULL);
@@ -811,7 +811,7 @@ m_vlapool_new(m_vlapool_t mem, m_gc_tid_t id, size_t size)
   return (ptr == NULL) ? NULL : M_ASSIGN_CAST(void *, ptr + offsetof(struct m_vlapool_slist_node_s, data));
 }
 
-static inline void
+M_INLINE void
 m_vlapool_del(m_vlapool_t mem, void *d, m_gc_tid_t id)
 {
   M_ASSERT(mem != NULL && mem->gc_mem != NULL);

--- a/m-concurrent.h
+++ b/m-concurrent.h
@@ -193,7 +193,7 @@
                                                                               \
   /* Initial the fields of the concurrent object not associated to the        \
   sub-container. */                                                           \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _internal_init)(concurrent_t out)                                 \
   {                                                                           \
     m_mutex_init(out->lock);                                                  \
@@ -204,7 +204,7 @@
                                                                               \
   /* Clear the fields of the concurrent object not associated to the          \
   sub-container. */                                                           \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _internal_clear)(concurrent_t out)                                \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -217,7 +217,7 @@
      write lock is exclusive.                                                 \
      NOTE: This instance doesn't implement the read/write strategy,           \
       and only get the lock */                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_lock)(const concurrent_t out)                               \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -227,7 +227,7 @@
   /* Free the read lock. See above.                                           \
      NOTE: This instance doesn't implement the read/write strategy,           \
       and only get the lock */                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_unlock)(const concurrent_t out)                             \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -236,7 +236,7 @@
                                                                               \
   /* Wait for a thread pushing some data in the container.                    \
      CONSTRAINT: the read lock shall be get before calling this service */    \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_wait)(const concurrent_t out)                               \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -247,7 +247,7 @@
      can get the read lock too.                                               \
      NOTE: This instance doesn't implement the read/write strategy,           \
       and only get the lock */                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_lock)(concurrent_t out)                                    \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -257,7 +257,7 @@
   /* Free the write lock.                                                     \
      NOTE: This instance doesn't implement the read/write strategy,           \
       and only get the lock */                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_unlock)(concurrent_t out)                                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -266,7 +266,7 @@
                                                                               \
   /* Wait for a thread pushing some data in the container.                    \
      CONSTRAINT: the write lock shall be get before calling this service */   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_wait)(const concurrent_t out)                              \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -275,7 +275,7 @@
                                                                               \
   /* Wait to all threads that some data are available in the container.       \
      CONSTRAINT: the write lock shall be get before calling this service */   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_signal)(concurrent_t out)                                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -295,7 +295,7 @@
 #define M_C0NCURRENT_DEF_COMMON(name, type, oplist, concurrent_t)             \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(concurrent_t out)                                          \
   {                                                                           \
     M_F(name, _internal_init)(out);                                           \
@@ -305,7 +305,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(INIT_SET, oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(concurrent_t out, concurrent_t const src)              \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(src);                                               \
@@ -319,7 +319,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(SET, oplist)(                                                   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(concurrent_t out, concurrent_t const src)                   \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -354,7 +354,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(CLEAR, oplist)(                                                 \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(concurrent_t out)                                         \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -366,7 +366,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(INIT_MOVE, oplist)(                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(concurrent_t out, concurrent_t src)                   \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(src);                                               \
@@ -380,7 +380,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(MOVE, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(concurrent_t out, concurrent_t src)                        \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -395,7 +395,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(SWAP, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(concurrent_t out, concurrent_t src)                        \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -421,7 +421,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(RESET, oplist)(                                                 \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(concurrent_t out)                                         \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -432,7 +432,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(EMPTY_P, oplist)(                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(concurrent_t const out)                                 \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -444,7 +444,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(GET_SIZE, oplist)(                                              \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(concurrent_t const out)                                    \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -456,7 +456,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(SET_KEY, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_at)(concurrent_t out, M_GET_KEY_TYPE oplist const key, M_GET_VALUE_TYPE oplist const data) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -468,7 +468,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(GET_KEY, oplist)(                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _get_copy)(M_GET_VALUE_TYPE oplist *out_data, const concurrent_t out, M_GET_KEY_TYPE oplist const key) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -484,7 +484,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(SAFE_GET_KEY, oplist)(                                          \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _safe_get_copy)(M_GET_VALUE_TYPE oplist *out_data, concurrent_t out, M_GET_KEY_TYPE oplist const key) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -498,7 +498,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(ERASE_KEY, oplist)(                                             \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _erase)(concurrent_t out, M_GET_KEY_TYPE oplist const key)        \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -512,7 +512,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(PUSH, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push)(concurrent_t out, M_GET_SUBTYPE oplist const data)         \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -526,7 +526,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(POP, oplist)(                                                   \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop)(M_GET_SUBTYPE oplist *p, concurrent_t out)                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -538,7 +538,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(PUSH_MOVE, oplist)(                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_move)(concurrent_t out, M_GET_SUBTYPE oplist *data)         \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -550,7 +550,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(POP_MOVE, oplist)(                                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_move)(M_GET_SUBTYPE oplist *p, concurrent_t out)             \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -562,7 +562,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t str, concurrent_t const out, bool a)         \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -573,7 +573,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *f, concurrent_t const out)                        \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -584,7 +584,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(PARSE_STR, oplist)(                                             \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(concurrent_t out, const char str[], const char **e)   \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -597,7 +597,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(IN_STR, oplist)(                                                \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(concurrent_t out, FILE *f)                               \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -610,7 +610,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, concurrent_t const out)          \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -622,7 +622,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(IN_SERIAL, oplist)(                                             \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(concurrent_t out, m_serial_read_t f)                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -635,7 +635,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(EQUAL, oplist)(                                                 \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(concurrent_t const out1, concurrent_t const out2)       \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out1);                                              \
@@ -662,7 +662,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(GET_KEY, oplist)(                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _get_blocking)(M_GET_VALUE_TYPE oplist *out_data, const concurrent_t out, M_GET_KEY_TYPE oplist const key, bool blocking) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -686,7 +686,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD2(POP, EMPTY_P, oplist)(                                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _pop_blocking)(M_GET_SUBTYPE oplist *p, concurrent_t out, bool blocking) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -709,7 +709,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD2(POP_MOVE, EMPTY_P, oplist)(                                    \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _pop_move_blocking)(M_GET_SUBTYPE oplist *p, concurrent_t out, bool blocking) \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -732,7 +732,7 @@
   ,)                                                                          \
                                                                               \
   M_IF_METHOD(HASH, oplist)(                                                  \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _hash)(concurrent_t const out)                                    \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -792,7 +792,7 @@
 /* Define the internal services for the lock strategy of a RP container */
 #define M_C0NCURRENT_RP_DEF_CORE(name, type, oplist, concurrent_t)            \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _internal_init)(concurrent_t out)                                 \
   {                                                                           \
     m_mutex_init(out->lock);                                                  \
@@ -804,7 +804,7 @@
     M_C0NCURRENT_CONTRACT(out);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _internal_clear)(concurrent_t out)                                \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -814,7 +814,7 @@
     out->self = NULL;                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_lock)(const concurrent_t out)                               \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -827,7 +827,7 @@
     m_mutex_unlock (self->lock);                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_unlock)(const concurrent_t out)                             \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -840,7 +840,7 @@
     m_mutex_unlock (self->lock);                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_lock)(concurrent_t out)                                    \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -855,7 +855,7 @@
     m_mutex_unlock (out->lock);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_unlock)(concurrent_t out)                                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -865,7 +865,7 @@
     m_mutex_unlock (out->lock);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_wait)(const concurrent_t out)                               \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -884,7 +884,7 @@
     m_mutex_unlock (out->self->lock);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_wait)(concurrent_t out)                                    \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \
@@ -902,7 +902,7 @@
     m_mutex_unlock (out->lock);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_signal)(concurrent_t out)                                  \
   {                                                                           \
     M_C0NCURRENT_CONTRACT(out);                                               \

--- a/m-core.h
+++ b/m-core.h
@@ -162,7 +162,7 @@
 #if __clang_major__ >= 6
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang push_options")                                               \
+  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")                    \
   _Pragma("clang diagnostic ignored \"-Wzero-as-null-pointer-constant\"")     \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
@@ -170,14 +170,13 @@
 #else
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang push_options")                                               \
+  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")                    \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
 #endif
 
 #define M_END_PROTECTED_CODE                                                  \
-  _Pragma("clang pop_options")                                                \
   _Pragma("clang diagnostic pop")
 
 #elif defined(__GNUC__) && defined(__cplusplus)
@@ -188,13 +187,12 @@
  */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC push_options")                                                 \
+  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wold-style-cast\"")                      \
   _Pragma("GCC diagnostic ignored \"-Wzero-as-null-pointer-constant\"")       \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
 
 #define M_END_PROTECTED_CODE                                                  \
-  _Pragma("GCC pop_options")                                                  \
   _Pragma("GCC diagnostic pop")
 
 #elif defined(__clang__)
@@ -202,12 +200,11 @@
 /* Warnings disabled for CLANG in C mode */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang push_options")                                               \
+  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
 
 #define M_END_PROTECTED_CODE                                                  \
-  _Pragma("clang pop_options")                                                \
   _Pragma("clang diagnostic pop")
 
 #elif defined(__GNUC__)
@@ -216,19 +213,18 @@
 /* Warnings disabled for GNU C in C mode (Wstringop-overflow produces false warnings) */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC push_options")                                                 \
+  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")                   \
   _Pragma("GCC diagnostic ignored \"-Wstringop-overflow\"")
 #else
 /* Warnings disabled for GNU C in C mode */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC push_options")                                                 \
+  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
 #endif
 
 #define M_END_PROTECTED_CODE                                                  \
-  _Pragma("GCC pop_options")                                                  \
   _Pragma("GCC diagnostic pop")
 
 #else
@@ -290,9 +286,9 @@ M_BEGIN_PROTECTED_CODE
    Otherwise uses the classic "M_INLINE"
 */
 #if   defined(__GNUC__) && defined(M_USE_EXTERN_DECL)
-#define M_INLINE _Pragma("GCC optimize (\"-fno-inline\")") inline
+#define M_INLINE __attribute__ ((noinline)) inline
 #elif defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
-#define M_INLINE _Pragma("GCC optimize (\"-fno-inline\")") extern inline
+#define M_INLINE __attribute__ ((noinline)) extern inline
 #else
 #define M_INLINE static inline
 #endif

--- a/m-core.h
+++ b/m-core.h
@@ -275,8 +275,8 @@ M_BEGIN_PROTECTED_CODE
 /************************************************************/
 
 /* Define default values */
-#ifndef M_USE_EXTERN_FINE_GRAINED
-#define M_USE_EXTERN_FINE_GRAINED 0
+#ifndef M_USE_EXTERN_FINE_SELECT
+#define M_USE_EXTERN_FINE_SELECT 0
 #endif
 
 /* The following semantics apply to inline in C99:
@@ -294,10 +294,10 @@ M_BEGIN_PROTECTED_CODE
 #define M_INLINE __attribute__ ((noinline)) inline
 #elif !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
 #define M_INLINE __attribute__ ((noinline)) extern inline
-#elif !defined( __cplusplus) && defined(__GNUC__) && M_USE_EXTERN_FINE_GRAINED
+#elif !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_FINE_GRAINED)
 #define M_INLINE                                                              \
-  M_IF(M_EQUAL(M_USE_EXTERN_FINE_GRAINED, 2))(__attribute__ ((noinline)) inline, \
-  M_IF(M_EQUAL(M_USE_EXTERN_FINE_GRAINED, 3))(__attribute__ ((noinline)) extern inline, \
+  M_IF(M_EQUAL(M_USE_EXTERN_FINE_SELECT, 2))(_Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"") __attribute__((weak, noinline)), \
+  M_IF(M_EQUAL(M_USE_EXTERN_FINE_SELECT, 3))(_Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"") __attribute__((noinline)), \
                                               static inline))
 #else
 #define M_INLINE static inline

--- a/m-core.h
+++ b/m-core.h
@@ -273,12 +273,13 @@ M_BEGIN_PROTECTED_CODE
    - extern inline: externally visible code is emitted, so at most one translation unit can use this.
    - static inline: No generation of an extern visible function. May inline or may call one static function.
 */
-/* If the user requests to use only declaration for all M*LIN functions (M_USE_EXTERN_DECL),
+/* If the user requests to use only declaration for all M*LIB functions globally (M_USE_DECL),
    it requests no inlining to the compiler and emits code as weak symbol.
-   Then at most one translation unit should request the definition of all functions (M_USE_EXTERN_DEF).
+   Then at most one translation unit should request the definition of all functions (M_USE_DEF).
    This is only supported by GCC and CLANG. You should also use the options -ffunction-sections -fdata-sections -Wl,--gc-sections
    Otherwise it would increase the size of the executable.
-   If M_USE_EXTERN_FINE_GRAINED, then uses a mechanism to decl or def the functions in function of M_USE_EXTERN_FINE_DECL / M_USE_EXTERN_FINE_DEF
+   If M_USE_FINE_GRAINED_LINKAGE, then the mechanism can be turn on / off dynamically in compilation time
+   to decl or def the functions in function of M_USE_DECL / M_USE_DEF
    Otherwise uses the classic "M_INLINE" (inline for C++ or static inline for C)
    inline in C++ as a weak definition by default, which may reduce code size in executable.
 */
@@ -287,16 +288,18 @@ M_BEGIN_PROTECTED_CODE
 #else
 # define M_INLINE_PRAGMA
 #endif
-#if defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
-#define M_INLINE M_INLINE_PRAGMA __attribute__((noinline)) extern
-#elif defined(__GNUC__) && defined(M_USE_EXTERN_DECL)
-#define M_INLINE M_INLINE_PRAGMA __attribute__((weak, noinline)) extern
-#elif defined(__GNUC__) && defined(M_USE_EXTERN_FINE_GRAINED)
+#if defined(__GNUC__) && defined(M_USE_FINE_GRAINED_LINKAGE)
 #define M_INLINE                                                              \
   M_IF_EMPTY(M_USE_DECL)(                                                  \
     M_IF_EMPTY(M_USE_DEF)(M_INLINE_PRAGMA __attribute__((noinline)) extern,  \
                           M_INLINE_PRAGMA __attribute__((weak, noinline)) extern), \
                           static inline)
+#elif defined(__GNUC__) && defined(M_USE_DECL)
+# ifdef M_USE_DEF
+#  define M_INLINE M_INLINE_PRAGMA __attribute__((noinline)) extern
+# else
+#  define M_INLINE M_INLINE_PRAGMA __attribute__((weak, noinline)) extern
+#endif
 #elif defined(__cplusplus) 
 #define M_INLINE inline
 #else

--- a/m-core.h
+++ b/m-core.h
@@ -274,6 +274,11 @@ M_BEGIN_PROTECTED_CODE
 /************************* LINKAGE **************************/
 /************************************************************/
 
+/* Define default values */
+#ifndef M_USE_EXTERN_FINE_GRAINED
+#define M_USE_EXTERN_FINE_GRAINED 0
+#endif
+
 /* The following semantics apply to inline in C99:
    - inline: No generation of an extern visible function. May inline or may call the external function.
    - extern inline: externally visible code is emitted, so at most one translation unit can use this.
@@ -285,13 +290,19 @@ M_BEGIN_PROTECTED_CODE
    This is only supported by GCC and CLANG.
    Otherwise uses the classic "M_INLINE"
 */
-#if   defined(__GNUC__) && defined(M_USE_EXTERN_DECL)
+#if !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_DECL)
 #define M_INLINE __attribute__ ((noinline)) inline
-#elif defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
+#elif !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
 #define M_INLINE __attribute__ ((noinline)) extern inline
+#elif !defined( __cplusplus) && defined(__GNUC__) && M_USE_EXTERN_FINE_GRAINED
+#define M_INLINE                                                              \
+  M_IF(M_EQUAL(M_USE_EXTERN_FINE_GRAINED, 2))(__attribute__ ((noinline)) inline, \
+  M_IF(M_EQUAL(M_USE_EXTERN_FINE_GRAINED, 3))(__attribute__ ((noinline)) extern inline, \
+                                              static inline))
 #else
 #define M_INLINE static inline
 #endif
+
 
 
 /************************************************************/

--- a/m-core.h
+++ b/m-core.h
@@ -162,7 +162,6 @@
 #if __clang_major__ >= 6
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")                    \
   _Pragma("clang diagnostic ignored \"-Wzero-as-null-pointer-constant\"")     \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
@@ -170,7 +169,6 @@
 #else
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wold-style-cast\"")                    \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
@@ -187,7 +185,6 @@
  */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wold-style-cast\"")                      \
   _Pragma("GCC diagnostic ignored \"-Wzero-as-null-pointer-constant\"")       \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
@@ -200,7 +197,6 @@
 /* Warnings disabled for CLANG in C mode */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("clang diagnostic push")                                            \
-  _Pragma("clang diagnostic ignored \"-Wattributes\"")                        \
   _Pragma("clang diagnostic ignored \"-Wunused-function\"")                   \
   _Pragma("clang diagnostic ignored \"-Wformat-nonliteral\"")
 
@@ -213,14 +209,12 @@
 /* Warnings disabled for GNU C in C mode (Wstringop-overflow produces false warnings) */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")                   \
   _Pragma("GCC diagnostic ignored \"-Wstringop-overflow\"")
 #else
 /* Warnings disabled for GNU C in C mode */
 #define M_BEGIN_PROTECTED_CODE                                                \
   _Pragma("GCC diagnostic push")                                              \
-  _Pragma("GCC diagnostic ignored \"-Wattributes\"")                          \
   _Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
 #endif
 
@@ -291,9 +285,9 @@ M_BEGIN_PROTECTED_CODE
    Otherwise uses the classic "M_INLINE"
 */
 #if !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_DECL)
-#define M_INLINE __attribute__ ((noinline)) inline
+#define M_INLINE _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"") __attribute__((weak, noinline))
 #elif !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_DEF)
-#define M_INLINE __attribute__ ((noinline)) extern inline
+#define M_INLINE _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"") __attribute__((noinline))
 #elif !defined( __cplusplus) && defined(__GNUC__) && defined(M_USE_EXTERN_FINE_GRAINED)
 #define M_INLINE                                                              \
   M_IF(M_EQUAL(M_USE_EXTERN_FINE_SELECT, 2))(_Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"") __attribute__((weak, noinline)), \

--- a/m-deque.h
+++ b/m-deque.h
@@ -170,7 +170,7 @@
 #define M_D3QU3_DEF_CORE(name, type, oplist, deque_t, it_t, node_t)           \
                                                                               \
   /* Allocate a new node for a deque */                                       \
-  static inline node_t*                                                       \
+  M_INLINE node_t*                                                            \
   M_C3(m_d3qu3_,name,_new_node)(deque_t d)                                    \
   {                                                                           \
     size_t def = d->default_size;                                             \
@@ -198,7 +198,7 @@
     return n;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(deque_t d)                                                 \
   {                                                                           \
     M_F(name, _node_list_init)(d->list);                                      \
@@ -214,7 +214,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(deque_t d)                                                \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -239,7 +239,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(deque_t d)                                                \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -252,7 +252,7 @@
     d->count = 0;                                                             \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_back_raw)(deque_t d)                                        \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -279,13 +279,13 @@
   }                                                                           \
                                                                               \
   /* Internal, for INIT_WITH */                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_raw)(deque_t d)                                             \
   {                                                                           \
     return M_F(name, _push_back_raw)(d);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back)(deque_t d, type const x)                              \
   {                                                                           \
     type *p = M_F(name, _push_back_raw)(d);                                   \
@@ -295,7 +295,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_back_new)(deque_t d)                                        \
   {                                                                           \
     type *p = M_F(name, _push_back_raw)(d);                                   \
@@ -306,7 +306,7 @@
   }                                                                           \
   , )                                                                         \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back_move)(deque_t d, type *x)                              \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -316,7 +316,7 @@
     M_DO_INIT_MOVE (oplist, *p, *x);                                          \
   }                                                                           \
                                                                               \
-  static inline type*                                                         \
+  M_INLINE type*                                                              \
   M_F(name, _push_front_raw)(deque_t d)                                       \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -341,7 +341,7 @@
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_front)(deque_t d, type const x)                             \
   {                                                                           \
     type *p = M_F(name, _push_front_raw)(d);                                  \
@@ -351,7 +351,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_front_new)(deque_t d)                                       \
   {                                                                           \
     type *p = M_F(name, _push_front_raw)(d);                                  \
@@ -362,7 +362,7 @@
   }                                                                           \
   ,)                                                                          \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_front_move)(deque_t d, type *x)                             \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -372,7 +372,7 @@
     M_DO_INIT_MOVE (oplist, *p, *x);                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_back)(type *ptr, deque_t d)                                  \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -408,7 +408,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_back_move)(type *ptr, deque_t d)                             \
   {                                                                           \
     M_ASSERT(ptr != NULL);                                                    \
@@ -418,7 +418,7 @@
   }                                                                           \
   , )                                                                         \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_front)(type *ptr, deque_t d)                                 \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -464,7 +464,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_front_move)(type *ptr, deque_t d)                            \
   {                                                                           \
     M_ASSERT(ptr != NULL);                                                    \
@@ -474,7 +474,7 @@
   }                                                                           \
   ,)                                                                          \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _back)(const deque_t d)                                           \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -489,7 +489,7 @@
     return &n->data[i-1];                                                     \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _front)(const deque_t d)                                          \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -499,14 +499,14 @@
     return &n->data[i];                                                       \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const deque_t d)                                           \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
     return d->count;                                                          \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity_back)(const deque_t v)                                  \
   {                                                                           \
     M_D3QU3_CONTRACT(v);                                                      \
@@ -520,7 +520,7 @@
     return s;                                                                 \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity_front)(const deque_t v)                                 \
   {                                                                           \
     M_D3QU3_CONTRACT(v);                                                      \
@@ -534,20 +534,20 @@
     return s;                                                                 \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity)(const deque_t v)                                       \
   {                                                                           \
     return M_F(name, _capacity_back)(v)+M_F(name, _capacity_front)(v);        \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const deque_t d)                                        \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
     return d->count == 0;                                                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const deque_t d)                                    \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -557,7 +557,7 @@
     it->deque = d;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(it_t it, const deque_t d)                               \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -572,7 +572,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, const deque_t d)                                \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -582,7 +582,7 @@
     it->deque = d;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it1, const it_t it2)                                \
   {                                                                           \
     M_ASSERT (it1 != NULL);                                                   \
@@ -592,7 +592,7 @@
     it1->deque = it2->deque;                                                  \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(it_t it)                                                  \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -602,7 +602,7 @@
           && it->index < it->deque->front->index);                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -621,7 +621,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(it_t it)                                               \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -640,7 +640,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(it_t it)                                                 \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -650,7 +650,7 @@
     return M_F(name, _end_p)(it2);                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(it_t it1, const it_t it2)                            \
   {                                                                           \
     M_ASSERT (it1 != NULL);                                                   \
@@ -660,7 +660,7 @@
       && it1->index == it2->index;                                            \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(it_t it)                                                    \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -668,7 +668,7 @@
     return &it->node->data[it->index];                                        \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -676,7 +676,7 @@
     return M_CONST_CAST(type, &it->node->data[it->index]);                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove)(deque_t d, it_t it)                                      \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -739,7 +739,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(deque_t d, const deque_t src)                          \
   {                                                                           \
     M_D3QU3_CONTRACT(src);                                                    \
@@ -766,7 +766,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(deque_t d, deque_t const src)                               \
   {                                                                           \
     if (M_UNLIKELY (src == d))                                                \
@@ -776,7 +776,7 @@
     M_F(name, _init_set)(d, src);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(deque_t d, deque_t src)                               \
   {                                                                           \
     M_D3QU3_CONTRACT(src);                                                    \
@@ -792,7 +792,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(deque_t d, deque_t src)                                    \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -802,7 +802,7 @@
     M_D3QU3_CONTRACT(d);                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(deque_t d, deque_t e)                                      \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -818,7 +818,7 @@
     M_D3QU3_CONTRACT(e);                                                      \
   }                                                                           \
                                                                               \
-  static inline type*                                                         \
+  M_INLINE type*                                                              \
   M_F(name, _get)(deque_t d, size_t key)                                      \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -837,13 +837,13 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cget)(deque_t d, size_t key)                                     \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _get)(d, key));                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_at)(deque_t d, size_t key, type const x)                     \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -854,7 +854,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(EQUAL, oplist)(                                                 \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const deque_t d1, const deque_t d2)                     \
   {                                                                           \
     M_D3QU3_CONTRACT(d1);                                                     \
@@ -877,7 +877,7 @@
   , /* NO EQUAL */)                                                           \
                                                                               \
   M_IF_METHOD(HASH, oplist)(                                                  \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _hash)(const deque_t d)                                           \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -892,7 +892,7 @@
   , /* NO HASH */)                                                            \
                                                                               \
   M_IF_METHOD(SWAP, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap_at)(deque_t d, size_t i, size_t j)                          \
   {                                                                           \
     M_D3QU3_CONTRACT(d);                                                      \
@@ -906,7 +906,7 @@
   , /* NO SWAP */)                                                            \
                                                                               \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t str, deque_t const deque, bool append)       \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -925,7 +925,7 @@
   , /* no GET_STR */ )                                                        \
                                                                               \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, const deque_t deque)                        \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -945,7 +945,7 @@
   , /* no OUT_STR */ )                                                        \
                                                                               \
   M_IF_METHOD2(PARSE_STR, INIT, oplist)(                                      \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(deque_t deque, const char str[], const char **endp)   \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -977,7 +977,7 @@
   , /* no PARSE_STR */ )                                                      \
                                                                               \
   M_IF_METHOD2(IN_STR, INIT, oplist)(                                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(deque_t deque, FILE *file)                               \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -1004,7 +1004,7 @@
   , /* no IN_STR */ )                                                         \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, const deque_t deque)             \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -1029,7 +1029,7 @@
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD2(IN_SERIAL, INIT, oplist)(                                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(deque_t deque, m_serial_read_t f)                     \
   {                                                                           \
     M_D3QU3_CONTRACT(deque);                                                  \
@@ -1055,7 +1055,7 @@
 
 /* Definition of the emplace_back function for deque */
 #define M_D3QUE_EMPLACE_BACK_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -1068,7 +1068,7 @@
 
 /* Definition of the emplace_front function for deque */
 #define M_D3QUE_EMPLACE_FRONT_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \

--- a/m-dict.h
+++ b/m-dict.h
@@ -333,7 +333,7 @@
   typedef value_type M_F(name, _value_ct);                                    \
   typedef dict_it_t M_F(name, _it_ct);                                        \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(dict_t map)                                                \
   {                                                                           \
     M_ASSERT (map != NULL);                                                   \
@@ -345,7 +345,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(dict_t map, const dict_t org)                          \
   {                                                                           \
     M_D1CT_CONTRACT(name, org);                                               \
@@ -357,7 +357,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(dict_t map, const dict_t org)                               \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
@@ -369,14 +369,14 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_clear)(dict_t map)                                                \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
     M_F(name, _array_list_pair_clear)(map->table);                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(dict_t map, dict_t org)                               \
   {                                                                           \
     M_D1CT_CONTRACT(name, org);                                               \
@@ -387,7 +387,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(dict_t d1, dict_t d2)                                      \
   {                                                                           \
     M_D1CT_CONTRACT(name, d1);                                                \
@@ -400,7 +400,7 @@
     M_D1CT_CONTRACT(name, d2);                                                \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(dict_t map, dict_t org)                                    \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
@@ -411,7 +411,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_reset)(dict_t map)                                                \
   {                                                                           \
     M_F(name, _array_list_pair_reset)(map->table);                            \
@@ -422,7 +422,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline value_type *                                                  \
+  M_INLINE value_type *                                                       \
   M_F(name, _get)(const dict_t map, key_type const key)                       \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
@@ -442,13 +442,13 @@
     return NULL;                                                              \
   }                                                                           \
                                                                               \
-  static inline value_type const *                                            \
+  M_INLINE value_type const *                                                 \
   M_F(name, _cget)(const dict_t map, key_type const key)                      \
   {                                                                           \
     return M_CONST_CAST(value_type, M_F(name,_get)(map,key));                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_d1ct_,name,_resize_up)(dict_t map)                                   \
   {                                                                           \
     /* NOTE: Contract may not be fulfilled here */                            \
@@ -488,7 +488,7 @@
     map->lower_limit = M_D1CT_LOWER_BOUND(new_size);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_d1ct_,name,_resize_down)(dict_t map)                                 \
   {                                                                           \
     /* NOTE: Contract may not be fulfilled here */                            \
@@ -513,7 +513,7 @@
     map->lower_limit = M_D1CT_LOWER_BOUND(new_size);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_IF(isSet)(M_F(name, _push), M_F(name, _set_at))                           \
        (dict_t map, key_type const key                                        \
         M_IF(isSet)(, M_DEFERRED_COMMA value_type const value))               \
@@ -545,7 +545,7 @@
     M_D1CT_CONTRACT(name, map);                                               \
   }                                                                           \
                                                                               \
-  static inline value_type *                                                  \
+  M_INLINE value_type *                                                       \
   M_F(name, _safe_get)(dict_t map, key_type const key)                        \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
@@ -578,7 +578,7 @@
     return &(*ref)->M_IF(isSet)(key, value);                                  \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _erase)(dict_t map, key_type const key)                           \
   {                                                                           \
     M_D1CT_CONTRACT(name, map);                                               \
@@ -606,7 +606,7 @@
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(dict_it_t it, const dict_t d)                                \
   {                                                                           \
     M_D1CT_CONTRACT(name, d);                                                 \
@@ -623,7 +623,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(dict_it_t it, const dict_it_t ref)                       \
   {                                                                           \
     M_ASSERT (it != NULL && ref != NULL);                                     \
@@ -632,21 +632,21 @@
     M_F(name, _list_pair_it_set)(it->list_it, ref->list_it);                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(dict_it_t it, const dict_t d)                            \
   {                                                                           \
     M_D1CT_CONTRACT(name, d);                                                 \
     M_F(name, _array_list_pair_it_end)(it->array_it, d->table);               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const dict_it_t it)                                       \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return M_F(name, _list_pair_end_p)(it->list_it);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(dict_it_t it)                                              \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
@@ -661,7 +661,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const dict_it_t it)                                      \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -671,7 +671,7 @@
     return M_F(name, _end_p)(it2);                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const dict_it_t it1, const dict_it_t it2)            \
   {                                                                           \
     M_ASSERT (it1 != NULL && it2 != NULL);                                    \
@@ -679,7 +679,7 @@
                                             it2->list_it);                    \
   }                                                                           \
                                                                               \
-  static inline it_deref_t *                                                  \
+  M_INLINE it_deref_t *                                                       \
   M_F(name, _ref)(const dict_it_t it)                                         \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
@@ -692,7 +692,7 @@
                                                                         )     \
   }                                                                           \
                                                                               \
-  static inline const it_deref_t *                                            \
+  M_INLINE const it_deref_t *                                                 \
   M_F(name, _cref)(const dict_it_t it)                                        \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
@@ -733,14 +733,14 @@
  */
 #define M_D1CT_FUNC_ADDITIONAL_DEF2(name, key_type, key_oplist, value_type, value_oplist, isSet, dict_t, dict_it_t, it_deref_t) \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name,_empty_p)(const dict_t map)                                        \
   {                                                                           \
     M_ASSERT(map != NULL);                                                    \
     return map->count == 0;                                                   \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name,_size)(const dict_t map)                                           \
   {                                                                           \
     M_ASSERT(map != NULL);                                                    \
@@ -748,7 +748,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(EQUAL, value_oplist)(                                           \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const dict_t dict1, const dict_t dict2)                 \
   {                                                                           \
     M_ASSERT (dict1 != NULL && dict2 != NULL);                                \
@@ -778,7 +778,7 @@
   , /* no value equal */ )                                                    \
                                                                               \
   M_IF_METHOD_BOTH(GET_STR, key_oplist, value_oplist)(                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t str, const dict_t dict, const bool append)   \
   {                                                                           \
     (append ? m_string_cat_cstr : m_string_set_cstr) (str, "{");              \
@@ -804,7 +804,7 @@
   , /* no GET_STR */ )                                                        \
                                                                               \
   M_IF_METHOD_BOTH(OUT_STR, key_oplist, value_oplist)(                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, const dict_t dict)                          \
   {                                                                           \
     M_ASSERT (file != NULL);                                                  \
@@ -831,7 +831,7 @@
   , /* no OUT_STR */ )                                                        \
                                                                               \
   M_IF_METHOD_BOTH(PARSE_STR, key_oplist, value_oplist)(                      \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(dict_t dict, const char str[], const char **endp)     \
   {                                                                           \
     M_ASSERT (str != NULL);                                                   \
@@ -876,7 +876,7 @@
   , /* no PARSE_STR */ )                                                      \
                                                                               \
   M_IF_METHOD_BOTH(IN_STR, key_oplist, value_oplist)(                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(dict_t dict, FILE *file)                                 \
   {                                                                           \
     M_ASSERT (file != NULL);                                                  \
@@ -918,7 +918,7 @@
   , /* no IN_STR */ )                                                         \
                                                                               \
   M_IF_METHOD_BOTH(OUT_SERIAL, key_oplist, value_oplist)(                     \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, dict_t const t1)                 \
   {                                                                           \
     M_ASSERT (f != NULL && f->m_interface != NULL);                           \
@@ -961,7 +961,7 @@
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD_BOTH(IN_SERIAL, key_oplist, value_oplist)(                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(dict_t t1, m_serial_read_t f)                         \
   {                                                                           \
     M_ASSERT (f != NULL && f->m_interface != NULL);                           \
@@ -1003,7 +1003,7 @@
   , /* no in_serial */ )                                                      \
                                                                               \
   M_IF(isSet)(                                                                \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(dict_t d1, dict_t d2)                                    \
   {                                                                           \
     dict_it_t it;                                                             \
@@ -1018,7 +1018,7 @@
   }                                                                           \
   ,                                                                           \
   M_IF_METHOD(ADD, value_oplist)(                                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(dict_t d1, dict_t d2)                                    \
   {                                                                           \
     dict_it_t it;                                                             \
@@ -1291,7 +1291,7 @@ enum m_d1ct_oa_element_e {
   typedef value_type M_F(name, _value_ct);                                    \
   typedef dict_it_t M_F(name, _it_ct);                                        \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_d1ct_,name,_update_limit)(dict_t dict, size_t size)                  \
   {                                                                           \
     /* FIXME: Overflow not handled. What to do in case of it? */              \
@@ -1299,7 +1299,7 @@ enum m_d1ct_oa_element_e {
     dict->lower_limit = (size <= M_D1CT_INITIAL_SIZE) ? 0 : (size_t) ((double) size * coeff_down) ; \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(dict_t dict)                                               \
   {                                                                           \
     M_ASSERT(0 <= (coeff_down) && (coeff_down)*2 < (coeff_up) && (coeff_up) < 1); \
@@ -1320,7 +1320,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(dict);                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(dict_t dict)                                              \
   {                                                                           \
     M_D1CT_OA_CONTRACT(dict);                                                 \
@@ -1337,7 +1337,7 @@ enum m_d1ct_oa_element_e {
     dict->data = NULL;                                                        \
   }                                                                           \
                                                                               \
-  static inline value_type *                                                  \
+  M_INLINE value_type *                                                       \
   M_F(name, _get)(const dict_t dict, key_type const key)                      \
   {                                                                           \
     M_D1CT_OA_CONTRACT(dict);                                                 \
@@ -1368,14 +1368,14 @@ enum m_d1ct_oa_element_e {
     return NULL;                                                              \
   }                                                                           \
                                                                               \
-  static inline value_type const *                                            \
+  M_INLINE value_type const *                                                 \
   M_F(name, _cget)(const dict_t map, key_type const key)                      \
   {                                                                           \
     return M_CONST_CAST(value_type, M_F(name,_get)(map,key));                 \
   }                                                                           \
                                                                               \
   M_IF_DEBUG(                                                                 \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C3(m_d1ct_,name,_control_after_resize)(const dict_t h)                    \
   {                                                                           \
     /* This function checks if the reshashing of the dict is ok */            \
@@ -1393,7 +1393,7 @@ enum m_d1ct_oa_element_e {
   }                                                                           \
   )                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_d1ct_,name,_resize_up)(dict_t h, size_t newSize, bool updateLimit)   \
   {                                                                           \
     size_t oldSize = h->mask+1;                                               \
@@ -1471,7 +1471,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(h);                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_IF(isSet)(M_F(name, _push), M_F(name,_set_at))                            \
        (dict_t dict, key_type const key                                       \
         M_IF(isSet)(, M_DEFERRED_COMMA value_type const value) )              \
@@ -1531,7 +1531,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(dict);                                                 \
   }                                                                           \
                                                                               \
-  static inline value_type *                                                  \
+  M_INLINE value_type *                                                       \
   M_F(name,_safe_get)(dict_t dict, key_type const key)                        \
   {                                                                           \
     M_D1CT_OA_CONTRACT(dict);                                                 \
@@ -1587,13 +1587,13 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(dict);                                                 \
     return &data[p].M_IF(isSet)(key, value);                                  \
   }                                                                           \
-  static inline M_ATTR_DEPRECATED value_type *                                \
+  M_INLINE M_ATTR_DEPRECATED value_type *                                     \
   M_F(name,_get_at)(dict_t dict, key_type const key)                          \
   {                                                                           \
     return M_F(name,_safe_get)(dict, key);                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_d1ct_,name,_resize_down)(dict_t h, size_t newSize)                   \
   {                                                                           \
     size_t oldSize = h->mask+1;                                               \
@@ -1671,7 +1671,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(h);                                                    \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name,_erase)(dict_t dict, key_type const key)                           \
   {                                                                           \
     M_D1CT_OA_CONTRACT(dict);                                                 \
@@ -1707,7 +1707,7 @@ enum m_d1ct_oa_element_e {
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(dict_t map, const dict_t org)                          \
   {                                                                           \
     M_D1CT_OA_CONTRACT(org);                                                  \
@@ -1735,7 +1735,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(map);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(dict_t map, const dict_t org)                               \
   {                                                                           \
     M_D1CT_OA_CONTRACT(map);                                                  \
@@ -1747,7 +1747,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(map);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(dict_t map, dict_t org)                               \
   {                                                                           \
     M_D1CT_OA_CONTRACT(org);                                                  \
@@ -1764,7 +1764,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(map);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(dict_t map, dict_t org)                                    \
   {                                                                           \
     M_D1CT_OA_CONTRACT(map);                                                  \
@@ -1776,7 +1776,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(map);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(dict_t d1, dict_t d2)                                      \
   {                                                                           \
     M_D1CT_OA_CONTRACT(d1);                                                   \
@@ -1791,7 +1791,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(d2);                                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(dict_t d)                                                 \
   {                                                                           \
     M_D1CT_OA_CONTRACT(d);                                                    \
@@ -1815,13 +1815,13 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT(d);                                                    \
   }                                                                           \
                                                                               \
-  static inline void M_ATTR_DEPRECATED                                        \
+  M_INLINE void M_ATTR_DEPRECATED                                             \
   M_F(name, _clean)(dict_t d)                                                 \
   {                                                                           \
     M_F(name, _reset)(d);                                                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(dict_it_t it, const dict_t d)                                \
   {                                                                           \
     M_D1CT_OA_CONTRACT(d);                                                    \
@@ -1836,7 +1836,7 @@ enum m_d1ct_oa_element_e {
     it->index = i;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(dict_it_t it, const dict_it_t ref)                       \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1846,7 +1846,7 @@ enum m_d1ct_oa_element_e {
     M_D1CT_OA_CONTRACT (it->dict);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(dict_it_t it, const dict_t d)                           \
   {                                                                           \
     M_D1CT_OA_CONTRACT(d);                                                    \
@@ -1861,7 +1861,7 @@ enum m_d1ct_oa_element_e {
     it->index = i;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(dict_it_t it, const dict_t d)                            \
   {                                                                           \
     M_D1CT_OA_CONTRACT(d);                                                    \
@@ -1870,7 +1870,7 @@ enum m_d1ct_oa_element_e {
     it->index = d->mask+1;                                                    \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const dict_it_t it)                                       \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1878,7 +1878,7 @@ enum m_d1ct_oa_element_e {
     return it->index > it->dict->mask;                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(dict_it_t it)                                              \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1892,7 +1892,7 @@ enum m_d1ct_oa_element_e {
     it->index = i;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(dict_it_t it)                                          \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1907,7 +1907,7 @@ enum m_d1ct_oa_element_e {
     it->index = i;                                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const dict_it_t it)                                      \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1917,7 +1917,7 @@ enum m_d1ct_oa_element_e {
     return M_F(name, _end_p)(it2);                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const dict_it_t it1,const dict_it_t it2)             \
   {                                                                           \
     M_ASSERT (it1 != NULL && it2 != NULL);                                    \
@@ -1926,7 +1926,7 @@ enum m_d1ct_oa_element_e {
     return it1->dict == it2->dict && it1->index == it2->index;                \
   }                                                                           \
                                                                               \
-  static inline it_deref_t *                                                  \
+  M_INLINE it_deref_t *                                                       \
   M_F(name, _ref)(const dict_it_t it)                                         \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -1938,13 +1938,13 @@ enum m_d1ct_oa_element_e {
     return &it->dict->data[i] M_IF(isSet)(.key, );                            \
   }                                                                           \
                                                                               \
-  static inline const  it_deref_t *                                           \
+  M_INLINE const  it_deref_t *                                                \
   M_F(name, _cref)(const dict_it_t it)                                        \
   {                                                                           \
     return M_CONST_CAST(it_deref_t, M_F(name, _ref)(it));                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_reserve)(dict_t dict, size_t capacity)                            \
   {                                                                           \
     M_D1CT_OA_CONTRACT(dict);                                                 \

--- a/m-funcobj.h
+++ b/m-funcobj.h
@@ -161,7 +161,7 @@
   /* Internal type for oplist & instance */                                   \
   typedef interface_t M_F(name, _ct);                                         \
                                                                               \
-  static inline retcode                                                       \
+  M_INLINE retcode                                                            \
   M_F(name, _call)(interface_t funcobj)                                       \
   {                                                                           \
     M_IF(M_KEYWORD_P(void, retcode)) ( /* nothing */,return)                  \
@@ -197,7 +197,7 @@
   /* Internal type for oplist & instance */                                   \
   typedef interface_t M_F(name, _ct);                                         \
                                                                               \
-  static inline retcode                                                       \
+  M_INLINE retcode                                                            \
   M_F(name, _call)(interface_t funcobj                                        \
                    M_MAP3(M_FUNC0BJ_BASE_ARGLIST, name, __VA_ARGS__) )        \
   {                                                                           \
@@ -220,7 +220,7 @@
   /* Internal type for oplist */                                              \
   typedef instance_t M_F(name, _ct);                                          \
                                                                               \
-  static inline M_C(base_name, _retcode_ct)                                   \
+  M_INLINE M_C(base_name, _retcode_ct)                                        \
   M_F(name, _callback)(M_C(base_name, _ct) _self                              \
                       M_IF_EMPTY(M_OPFLAT param_list)(                        \
                           /* No param */,                                     \
@@ -233,25 +233,25 @@
     callback_core;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_with)(instance_t obj)                                       \
   {                                                                           \
     obj->callback = M_F(name, _callback);                                     \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(instance_t obj)                                           \
   {                                                                           \
     (void) obj; /* nothing to do */                                           \
   }                                                                           \
                                                                               \
-  static inline struct M_C(base_name, _s) *                                   \
+  M_INLINE struct M_C(base_name, _s) *                                        \
   M_F(name, _as_interface)(instance_t obj)                                    \
   {                                                                           \
     return (struct M_C(base_name, _s) *) obj;                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(instance_t obj)                                            \
   {                                                                           \
     obj->callback = M_F(name, _callback);                                     \
@@ -306,7 +306,7 @@
                                                                               \
   M_FUNC0BJ_CONTROL_ALL_OPLIST(name, __VA_ARGS__)                             \
                                                                               \
-  static inline M_C(base_name, _retcode_ct)                                   \
+  M_INLINE M_C(base_name, _retcode_ct)                                        \
   M_F(name, _callback)(M_C(base_name, _ct) _self                              \
                       M_IF_EMPTY(M_OPFLAT param_list)(                        \
                         /* No param */,                                       \
@@ -321,20 +321,20 @@
     callback_core;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_with)(instance_t obj M_MAP(M_FUNC0BJ_INS_ATTR_LIST, __VA_ARGS__)) \
   {                                                                           \
     obj->callback = M_F(name, _callback);                                     \
     M_MAP(M_FUNC0BJ_INS_ATTR_INIT_SET, __VA_ARGS__);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(instance_t obj)                                           \
   {                                                                           \
     M_MAP(M_FUNC0BJ_INS_ATTR_CLEAR, __VA_ARGS__);                             \
   }                                                                           \
                                                                               \
-  static inline struct M_C(base_name, _s) *                                   \
+  M_INLINE struct M_C(base_name, _s) *                                        \
   M_F(name, _as_interface)(instance_t obj)                                    \
   {                                                                           \
     return (struct M_C(base_name, _s) *) obj;                                 \
@@ -342,7 +342,7 @@
                                                                               \
   M_IF(M_FUNC0BJ_TEST_METHOD_P(INIT, __VA_ARGS))                              \
   (                                                                           \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(instance_t obj)                                            \
   {                                                                           \
     obj->callback = M_F(name, _callback);                                     \

--- a/m-genint.h
+++ b/m-genint.h
@@ -103,7 +103,7 @@ typedef struct m_genint_s {
  * meaning it can be used to index global unique resources shared 
  * for all threads.
  */
-static inline void
+M_INLINE void
 m_genint_init(m_genint_t s, unsigned int n)
 {
   M_ASSERT (s != NULL && n > 0 && n <= M_GENINT_MAX_ALLOC);
@@ -126,7 +126,7 @@ m_genint_init(m_genint_t s, unsigned int n)
 }
 
 /* Clear an integer generator (Destructor) */
-static inline void
+M_INLINE void
 m_genint_clear(m_genint_t s)
 {
   M_GEN1NT_CONTRACT(s);
@@ -135,7 +135,7 @@ m_genint_clear(m_genint_t s)
 }
 
 /* Return the maximum integer that the generator will provide */
-static inline size_t
+M_INLINE size_t
 m_genint_size(m_genint_t s)
 {
   M_GEN1NT_CONTRACT(s);
@@ -144,7 +144,7 @@ m_genint_size(m_genint_t s)
 
 /* Get an unique integer from the integer generator.
  * NOTE: For a typical case, the amortized cost is one CAS per pop. */
-static inline unsigned int
+M_INLINE unsigned int
 m_genint_pop(m_genint_t s)
 {
   M_GEN1NT_CONTRACT(s);
@@ -204,7 +204,7 @@ m_genint_pop(m_genint_t s)
 
 /* Restore a used integer in the integer generator.
  * NOTE: For a typical case, the amortized cost is one CAS per pop */
-static inline void
+M_INLINE void
 m_genint_push(m_genint_t s, unsigned int n)
 {
   M_GEN1NT_CONTRACT(s);

--- a/m-i-list.h
+++ b/m-i-list.h
@@ -198,7 +198,7 @@ typedef struct m_il1st_head_s {
 /* Define core functions for intrusive lists */
 #define M_IL1ST_DEF_CORE(name, type, oplist, list_t, it_t)                    \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(list_t list)                                               \
   {                                                                           \
     M_ASSERT (list != NULL);                                                  \
@@ -207,7 +207,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(list_t list)                                              \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -229,7 +229,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(list_t list)                                              \
   {                                                                           \
     /* Nothing to do more than clean the list itself */                       \
@@ -239,7 +239,7 @@ typedef struct m_il1st_head_s {
     list->name.prev = NULL;                                                   \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const list_t list)                                      \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -247,7 +247,7 @@ typedef struct m_il1st_head_s {
   }                                                                           \
                                                                               \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(list_t list, list_t ref)                              \
   {                                                                           \
     M_IL1ST_CONTRACT(name, ref);                                              \
@@ -264,14 +264,14 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(list_t list, list_t ref)                                   \
   {                                                                           \
     M_F(name, _clear)(list);                                                  \
     M_F(name, _init_move)(list, ref);                                         \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const list_t list)                                         \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -285,7 +285,7 @@ typedef struct m_il1st_head_s {
     return s;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back)(list_t list, type *obj)                               \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -298,7 +298,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_front)(list_t list, type *obj)                              \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -311,7 +311,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_after)(type *obj_pos, type *obj)                            \
   {                                                                           \
     M_ASSERT (obj_pos != NULL && obj != NULL);                                \
@@ -324,7 +324,7 @@ typedef struct m_il1st_head_s {
     next->prev = &obj->name;                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_field)(type *obj)                                           \
   {                                                                           \
     M_ASSERT (obj != NULL);                                                   \
@@ -333,7 +333,7 @@ typedef struct m_il1st_head_s {
     obj->name.prev = NULL;                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _unlink)(type *obj)                                               \
   {                                                                           \
     M_ASSERT (obj != NULL);                                                   \
@@ -348,7 +348,7 @@ typedef struct m_il1st_head_s {
     obj->name.prev = NULL;                                                    \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _back)(const list_t list)                                         \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -357,7 +357,7 @@ typedef struct m_il1st_head_s {
                              struct m_il1st_head_s, name);                    \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _front)(const list_t list)                                        \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -366,7 +366,7 @@ typedef struct m_il1st_head_s {
                              struct m_il1st_head_s, name);                    \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _next_obj)(const list_t list, type const *obj)                    \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -377,7 +377,7 @@ typedef struct m_il1st_head_s {
                         struct m_il1st_head_s, name);                         \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _previous_obj)(const list_t list, type const *obj)                \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -388,7 +388,7 @@ typedef struct m_il1st_head_s {
                         struct m_il1st_head_s, name);                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const list_t list)                                  \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -400,7 +400,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it, const it_t cit)                                 \
   {                                                                           \
     M_ASSERT (it != NULL && cit != NULL);                                     \
@@ -411,7 +411,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(it_t it, list_t const list)                             \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -423,7 +423,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, list_t const list)                              \
   {                                                                           \
     M_ASSERT (it != NULL && list != NULL);                                    \
@@ -434,7 +434,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -442,7 +442,7 @@ typedef struct m_il1st_head_s {
     return it->current == it->head;                                           \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const it_t it)                                           \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -450,7 +450,7 @@ typedef struct m_il1st_head_s {
     return it->next == it->head || it->current == it->head;                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -465,7 +465,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(it_t it)                                               \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -480,7 +480,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_NODE_CONTRACT(it->current);                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1, const it_t it2 )                     \
   {                                                                           \
     M_ASSERT (it1 != NULL && it2 != NULL);                                    \
@@ -488,7 +488,7 @@ typedef struct m_il1st_head_s {
     return it1->head == it2->head && it1->current == it2->current;            \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(const it_t it)                                              \
   {                                                                           \
     M_ASSERT (it != NULL && it->current != NULL);                             \
@@ -501,14 +501,14 @@ typedef struct m_il1st_head_s {
                              struct m_il1st_head_s, name);                    \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     type *ptr = M_F(name, _ref)(it);                                          \
     return M_CONST_CAST(type, ptr);                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove)(list_t list, it_t it)                                    \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -523,7 +523,7 @@ typedef struct m_il1st_head_s {
   }                                                                           \
                                                                               \
   M_IF_METHOD2(NEW, INIT_SET, oplist)(                                        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _insert)(list_t list, it_t it, type x)                            \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -542,7 +542,7 @@ typedef struct m_il1st_head_s {
   }                                                                           \
   , /* NEW & INIT_SET not defined */)                                         \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _pop_back)(list_t list)                                           \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -553,7 +553,7 @@ typedef struct m_il1st_head_s {
     return obj;                                                               \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _pop_front)(list_t list)                                          \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \
@@ -564,7 +564,7 @@ typedef struct m_il1st_head_s {
     return obj;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(list_t list1, list_t list2)                              \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list1);                                            \
@@ -581,7 +581,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, list2);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_back)(list_t nv, list_t ov, it_t it)                      \
   {                                                                           \
     M_IL1ST_CONTRACT(name, nv);                                               \
@@ -597,7 +597,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, ov);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_at)(list_t nlist, it_t npos,                              \
                         list_t olist, it_t opos)                              \
   {                                                                           \
@@ -627,7 +627,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, olist);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(list_t d, list_t e)                                        \
   {                                                                           \
     M_IL1ST_CONTRACT(name, d);                                                \
@@ -650,7 +650,7 @@ typedef struct m_il1st_head_s {
     M_IL1ST_CONTRACT(name, e);                                                \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reverse)(list_t list)                                            \
   {                                                                           \
     M_IL1ST_CONTRACT(name, list);                                             \

--- a/m-i-shared.h
+++ b/m-i-shared.h
@@ -55,13 +55,13 @@ M_BEGIN_PROTECTED_CODE
   ATOMIC_VAR_INIT(0)
 
 
-/* Define the intrusive shared pointer type and its static inline functions.
+/* Define the intrusive shared pointer type and its M_INLINE functions.
    USAGE: ISHARED_PTR_DEF(name, type, [, oplist]) */
 #define M_ISHARED_PTR_DEF(name, ...)                                          \
   M_ISHARED_PTR_DEF_AS(name, M_F(name,_t), __VA_ARGS__)
 
 
-/* Define the intrusive shared pointer type and its static inline functions
+/* Define the intrusive shared pointer type and its M_INLINE functions
   as the name name_t
    USAGE: ISHARED_PTR_DEF_AS(name, name_t, type, [, oplist]) */
 #define M_ISHARED_PTR_DEF_AS(name, name_t, ...)                               \
@@ -132,7 +132,7 @@ M_BEGIN_PROTECTED_CODE
 /* Define the core functions */
 #define M_ISHAR3D_PTR_DEF_CORE(name, type, oplist, shared_t)                  \
                                                                               \
-  static inline shared_t                                                      \
+  M_INLINE shared_t                                                           \
   M_F(name, _init)(type *ptr)                                                 \
   {                                                                           \
     /* Initialize the type referenced by the pointer */                       \
@@ -142,7 +142,7 @@ M_BEGIN_PROTECTED_CODE
     return ptr;                                                               \
   }                                                                           \
                                                                               \
-  static inline shared_t                                                      \
+  M_INLINE shared_t                                                           \
   M_F(name, _init_set)(shared_t shared)                                       \
   {                                                                           \
     if (M_LIKELY (shared != NULL)) {                                          \
@@ -156,7 +156,7 @@ M_BEGIN_PROTECTED_CODE
   M_IF_DISABLED_METHOD(NEW, oplist)                                           \
   (                                                                           \
   /* This function is only for static object */                               \
-  static inline shared_t                                                      \
+  M_INLINE shared_t                                                           \
   M_F(name, _init_once)(type *shared)                                         \
   {                                                                           \
     if (M_LIKELY (shared != NULL)) {                                          \
@@ -187,7 +187,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
   ,                                                                           \
   /* This function is only for dynamic object */                              \
-  static inline shared_t                                                      \
+  M_INLINE shared_t                                                           \
   M_F(name, _init_new)(void)                                                  \
   {                                                                           \
     type *ptr = M_CALL_NEW(oplist, type);                                     \
@@ -202,7 +202,7 @@ M_BEGIN_PROTECTED_CODE
     /* End of NEW */)                                                         \
   , /* End of INIT */)                                                        \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(shared_t shared)                                          \
   {                                                                           \
     if (shared != NULL) {                                                     \
@@ -213,7 +213,7 @@ M_BEGIN_PROTECTED_CODE
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear_ptr)(shared_t *shared)                                     \
   {                                                                           \
     M_ASSERT(shared != NULL);                                                 \
@@ -221,14 +221,14 @@ M_BEGIN_PROTECTED_CODE
     *shared = NULL;                                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(shared_t *shared)                                         \
   {                                                                           \
     M_F(name, _clear)(*shared);                                               \
     *shared = NULL;                                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(shared_t *ptr, shared_t shared)                             \
   {                                                                           \
     M_ASSERT (ptr != NULL);                                                   \

--- a/m-list.h
+++ b/m-list.h
@@ -161,19 +161,19 @@
                                                                               \
     MEMPOOL_DEF(M_F(name, _mempool), struct M_F(name, _s))                    \
     M_GET_MEMPOOL_LINKAGE oplist M_F(name, _mempool_t) M_GET_MEMPOOL oplist;  \
-    static inline struct M_F(name, _s) *M_C3(m_l1st_,name,_new)(void) {       \
+    M_INLINE struct M_F(name, _s) *M_C3(m_l1st_,name,_new)(void) {            \
       return M_F(name, _mempool_alloc)(M_GET_MEMPOOL oplist);                 \
     }                                                                         \
-    static inline void M_C3(m_l1st_,name,_del)(struct M_F(name, _s) *ptr) {   \
+    M_INLINE void M_C3(m_l1st_,name,_del)(struct M_F(name, _s) *ptr) {        \
       M_F(name, _mempool_free)(M_GET_MEMPOOL oplist, ptr);                    \
     }                                                                         \
                                                                               \
     , /* No mempool allocation */                                             \
                                                                               \
-    static inline struct M_F(name, _s) *M_C3(m_l1st_,name,_new)(void) {       \
+    M_INLINE struct M_F(name, _s) *M_C3(m_l1st_,name,_new)(void) {            \
       return M_CALL_NEW(oplist, struct M_F(name, _s));                        \
     }                                                                         \
-    static inline void M_C3(m_l1st_,name,_del)(struct M_F(name, _s) *ptr) {   \
+    M_INLINE void M_C3(m_l1st_,name,_del)(struct M_F(name, _s) *ptr) {        \
       M_CALL_DEL(oplist, ptr);                                                \
     }                                                                         \
     )                                                                         \
@@ -231,14 +231,14 @@
  */
 #define M_L1ST_DEF_P4(name, type, oplist, list_t, it_t)                       \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(list_t v)                                                  \
   {                                                                           \
     M_ASSERT (v != NULL);                                                     \
     *v = NULL;                                                                \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(list_t v)                                                 \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -253,13 +253,13 @@
     M_L1ST_CONTRACT(v);                                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(list_t v)                                                 \
   {                                                                           \
     M_F(name, _reset)(v);                                                     \
   }                                                                           \
                                                                               \
-  static inline type  *                                                       \
+  M_INLINE type  *                                                            \
   M_F(name, _back)(const list_t v)                                            \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -267,7 +267,7 @@
     return &((*v)->data);                                                     \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_raw)(list_t v)                                              \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -284,7 +284,7 @@
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back)(list_t v, type const x)                               \
   {                                                                           \
     type *data = M_F(name, _push_raw)(v);                                     \
@@ -294,7 +294,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_new)(list_t v)                                              \
   {                                                                           \
     type *data = M_F(name, _push_raw)(v);                                     \
@@ -305,7 +305,7 @@
   }                                                                           \
   , /* No INIT */)                                                            \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_back)(type *data, list_t v)                                  \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -321,7 +321,7 @@
     M_L1ST_CONTRACT(v);                                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_move)(list_t v, type *x)                                    \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -331,7 +331,7 @@
     M_DO_INIT_MOVE (oplist, *data, *x);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_move)(type *data, list_t v)                                  \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -343,14 +343,14 @@
     M_L1ST_CONTRACT(v);                                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const list_t v)                                         \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
     return *v == NULL;                                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(list_t l, list_t v)                                        \
   {                                                                           \
     M_L1ST_CONTRACT(l);                                                       \
@@ -360,7 +360,7 @@
     M_L1ST_CONTRACT(v);                                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const list_t v)                                     \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -369,7 +369,7 @@
     it->previous = NULL;                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it1, const it_t it2)                                \
   {                                                                           \
     M_ASSERT (it1 != NULL && it2 != NULL);                                    \
@@ -377,7 +377,7 @@
     it1->previous = it2->previous;                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it1, const list_t v)                                \
   {                                                                           \
     M_L1ST_CONTRACT(v);                                                       \
@@ -387,21 +387,21 @@
     it1->previous = NULL;                                                     \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return it->current == NULL;                                               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const it_t it)                                           \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return it->current == NULL || it->current->next == NULL;                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
@@ -409,28 +409,28 @@
     it->current  = it->current->next;                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1, const it_t it2)                      \
   {                                                                           \
     M_ASSERT(it1 != NULL && it2 != NULL);                                     \
     return it1->current == it2->current;                                      \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(const it_t it)                                              \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
     return &(it->current->data);                                              \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
     return M_CONST_CAST(type, &(it->current->data));                          \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const list_t list)                                         \
   {                                                                           \
     M_L1ST_CONTRACT(list);                                                    \
@@ -443,7 +443,7 @@
     return size;                                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _sublist_p)(const list_t list, const it_t itsub)                  \
   {                                                                           \
     M_L1ST_CONTRACT(list);                                                    \
@@ -457,7 +457,7 @@
     return (itsub->current == NULL);                                          \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _get)(const list_t list, size_t i)                                \
   {                                                                           \
     M_L1ST_CONTRACT(list);                                                    \
@@ -474,13 +474,13 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cget)(const list_t l, size_t i)                                  \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _get)(l,i));                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _insert)(list_t list, it_t insertion_point,                       \
                      type const x)                                            \
   {                                                                           \
@@ -506,7 +506,7 @@
     M_L1ST_CONTRACT(list);                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove)(list_t list, it_t removing_point)                        \
   {                                                                           \
     M_L1ST_CONTRACT(list);                                                    \
@@ -525,7 +525,7 @@
     M_L1ST_CONTRACT(list);                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(list_t list, const list_t org)                         \
   {                                                                           \
     M_L1ST_CONTRACT(org);                                                     \
@@ -549,7 +549,7 @@
     M_L1ST_CONTRACT(list);                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(list_t list, const list_t org)                              \
   {                                                                           \
     if (M_UNLIKELY (list == org)) return;                                     \
@@ -557,7 +557,7 @@
     M_F(name, _init_set)(list, org);                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(list_t list, list_t org)                              \
   {                                                                           \
     M_L1ST_CONTRACT(org);                                                     \
@@ -566,7 +566,7 @@
     *org = NULL;  /* safer */                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(list_t list, list_t org)                                   \
   {                                                                           \
     M_ASSERT (list != org);                                                   \
@@ -574,7 +574,7 @@
     M_F(name, _init_move)(list, org);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_back)(list_t nv, list_t ov, it_t it)                      \
   {                                                                           \
     M_L1ST_CONTRACT(nv);                                                      \
@@ -598,7 +598,7 @@
     *nv = current;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_at)(list_t nlist, it_t npos,                              \
                         list_t olist, it_t opos)                              \
   {                                                                           \
@@ -636,7 +636,7 @@
     M_L1ST_CONTRACT(olist);                                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(list_t list1, list_t list2)                              \
   {                                                                           \
     M_L1ST_CONTRACT(list1);                                                   \
@@ -652,7 +652,7 @@
     *list2 = NULL;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reverse)(list_t list)                                            \
   {                                                                           \
     M_L1ST_CONTRACT(list);                                                    \
@@ -682,7 +682,7 @@
 #define M_L1ST_ITBASE_DEF(name, type, oplist, list_t, it_t)                   \
                                                                               \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t str, const list_t list,                      \
                       bool append)                                            \
   {                                                                           \
@@ -702,7 +702,7 @@
   , /* no str */ )                                                            \
                                                                               \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, const list_t list)                          \
   {                                                                           \
     M_ASSERT (file != NULL && list != NULL);                                  \
@@ -721,7 +721,7 @@
   , /* no out_str */ )                                                        \
                                                                               \
   M_IF_METHOD2(PARSE_STR, INIT, oplist)(                                      \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(list_t list, const char str[], const char **endp)     \
   {                                                                           \
     M_ASSERT (str != NULL && list != NULL);                                   \
@@ -752,7 +752,7 @@
   , /* no PARSE_STR & INIT */ )                                               \
                                                                               \
   M_IF_METHOD2(IN_STR, INIT, oplist)(                                         \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(list_t list, FILE *file)                                 \
   {                                                                           \
     M_ASSERT (file != NULL && list != NULL);                                  \
@@ -778,7 +778,7 @@
   , /* no IN_STR & INIT */ )                                                  \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, const list_t list)               \
   {                                                                           \
     M_ASSERT (list != NULL);                                                  \
@@ -807,7 +807,7 @@
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD2(IN_SERIAL, INIT, oplist)(                                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(list_t list, m_serial_read_t f)                       \
   {                                                                           \
     M_ASSERT (list != NULL);                                                  \
@@ -833,7 +833,7 @@
   , /* no IN_SERIAL & INIT */ )                                               \
                                                                               \
   M_IF_METHOD(EQUAL, oplist)(                                                 \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const list_t list1, const list_t list2)                 \
   {                                                                           \
     M_ASSERT (list1 != NULL && list2 != NULL);                                \
@@ -857,7 +857,7 @@
   , /* no equal */ )                                                          \
                                                                               \
   M_IF_METHOD(HASH, oplist)(                                                  \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _hash)(const list_t list)                                         \
   {                                                                           \
     M_ASSERT (list != NULL);                                                  \
@@ -877,7 +877,7 @@
 
 /* Definition of the emplace_back function for single list */
 #define M_L1ST_EMPLACE_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -890,7 +890,7 @@
 
 /* Definition of the emplace_back function for dual push list */
 #define M_L1ST_EMPLACE_BACK_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -903,7 +903,7 @@
 
 /* Definition of the emplace_front function for dual push list */
 #define M_L1ST_EMPLACE_FRONT_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t v                                                      \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -987,7 +987,7 @@
  */
 #define M_L1ST_DUAL_PUSH_DEF_P4(name, type, oplist, list_t, it_t)             \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(list_t v)                                                  \
   {                                                                           \
     M_ASSERT( v != NULL);                                                     \
@@ -996,7 +996,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(list_t v)                                                 \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1012,13 +1012,13 @@
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(list_t v)                                                 \
   {                                                                           \
     M_F(name, _reset)(v);                                                     \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _back)(const list_t v)                                            \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1026,7 +1026,7 @@
     return &(v->back->data);                                                  \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_back_raw)(list_t v)                                         \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1048,13 +1048,13 @@
   }                                                                           \
                                                                               \
   /* Internal, for INIT_WITH */                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_raw)(list_t d)                                              \
   {                                                                           \
     return M_F(name, _push_back_raw)(d);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back)(list_t v, type const x)                               \
   {                                                                           \
     type *data = M_F(name, _push_back_raw)(v);                                \
@@ -1064,7 +1064,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_back_new)(list_t v)                                         \
   {                                                                           \
     type *data = M_F(name, _push_back_raw)(v);                                \
@@ -1075,7 +1075,7 @@
   }                                                                           \
   , /* No INIT */ )                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_back_move)(list_t v, type *x)                               \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -1085,13 +1085,13 @@
     M_DO_INIT_MOVE (oplist, *data, *x);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_move)(list_t v, type *x)                                    \
   {                                                                           \
     M_F(name, _push_back_move)(v, x);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_back)(type *data, list_t v)                                  \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1112,7 +1112,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop_move)(type *data, list_t v)                                  \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1130,7 +1130,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _front)(list_t v)                                                 \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1138,7 +1138,7 @@
     return &(v->front->data);                                                 \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_front_raw)(list_t v)                                        \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1160,7 +1160,7 @@
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_front)(list_t v, type const x)                              \
   {                                                                           \
     type *data = M_F(name, _push_front_raw)(v);                               \
@@ -1169,7 +1169,7 @@
     M_CALL_INIT_SET(oplist, *data, x);                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push_front_move)(list_t v, type *x)                              \
   {                                                                           \
     M_ASSERT (x != NULL);                                                     \
@@ -1180,7 +1180,7 @@
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _push_front_new)(list_t v)                                        \
   {                                                                           \
     type *data = M_F(name, _push_back_raw)(v);                                \
@@ -1191,14 +1191,14 @@
   }                                                                           \
   , /* No INIT */)                                                            \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const list_t v)                                         \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
     return v->back == NULL;                                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(list_t l, list_t v)                                        \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(l);                                             \
@@ -1207,7 +1207,7 @@
     M_SWAP(struct M_F(name, _s) *, l->back, v->back);                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const list_t v)                                     \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1216,7 +1216,7 @@
     it->previous = NULL;                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it1, const it_t it2)                                \
   {                                                                           \
     M_ASSERT (it1 != NULL && it2 != NULL);                                    \
@@ -1224,7 +1224,7 @@
     it1->previous = it2->previous;                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it1, const list_t v)                                \
   {                                                                           \
     M_ASSERT (it1 != NULL);                                                   \
@@ -1234,21 +1234,21 @@
     it1->previous = NULL;                                                     \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return it->current == NULL;                                               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const it_t it)                                           \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return it->current == NULL || it->current->next == NULL;                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
@@ -1256,28 +1256,28 @@
     it->current  = it->current->next;                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1, const it_t it2)                      \
   {                                                                           \
     M_ASSERT(it1 != NULL && it2 != NULL);                                     \
     return it1->current == it2->current;                                      \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(const it_t it)                                              \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
     return &(it->current->data);                                              \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     M_ASSERT(it != NULL && it->current != NULL);                              \
     return M_CONST_CAST(type, &(it->current->data));                          \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const list_t v)                                            \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(v);                                             \
@@ -1290,7 +1290,7 @@
     return size;                                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _insert)(list_t list, it_t insertion_point,                       \
                      type const x)                                            \
   {                                                                           \
@@ -1319,7 +1319,7 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _remove)(list_t list, it_t removing_point)                        \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(list);                                          \
@@ -1342,7 +1342,7 @@
     removing_point->current = next;                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(list_t list, const list_t org)                              \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(list);                                          \
@@ -1369,7 +1369,7 @@
     *update_list = NULL;                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(list_t list, const list_t org)                         \
   {                                                                           \
     M_ASSERT (list != org);                                                   \
@@ -1377,7 +1377,7 @@
     M_F(name, _set)(list, org);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(list_t list, list_t org)                              \
   {                                                                           \
     M_ASSERT (list != org);                                                   \
@@ -1387,14 +1387,14 @@
     org->front = NULL;                                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(list_t list, list_t org)                                   \
   {                                                                           \
     M_F(name, _clear)(list);                                                  \
     M_F(name, _init_move)(list, org);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_back)(list_t list1, list_t list2, it_t it)                \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(list1);                                         \
@@ -1426,7 +1426,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(list2);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice_at)(list_t nlist, it_t npos,                              \
                         list_t olist, it_t opos)                              \
   {                                                                           \
@@ -1474,7 +1474,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(olist);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _splice)(list_t list1, list_t list2)                              \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(list1);                                         \
@@ -1494,7 +1494,7 @@
     M_L1ST_DUAL_PUSH_CONTRACT(list2);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reverse)(list_t list)                                            \
   {                                                                           \
     M_L1ST_DUAL_PUSH_CONTRACT(list);                                          \

--- a/m-mempool.h
+++ b/m-mempool.h
@@ -109,7 +109,7 @@
 /* Define the core functions of the mempool */
 #define M_M3MPOOL_DEF_CORE(name, type, name_t)                                \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_init)(name_t mem)                                                 \
   {                                                                           \
     mem->free_list = NULL;                                                    \
@@ -123,7 +123,7 @@
     M_M3MPOOL_CONTRACT(mem, type);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_clear)(name_t mem)                                                \
   {                                                                           \
     M_M3MPOOL_CONTRACT(mem, type);                                            \
@@ -138,7 +138,7 @@
     mem->current_segment = NULL;                                              \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name,_alloc)(name_t mem)                                                \
   {                                                                           \
     M_M3MPOOL_CONTRACT(mem, type);                                            \
@@ -173,7 +173,7 @@
     return &ret->t;                                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name,_free)(name_t mem, type *ptr)                                      \
   {                                                                           \
     M_M3MPOOL_CONTRACT(mem, type);                                            \

--- a/m-prioqueue.h
+++ b/m-prioqueue.h
@@ -161,95 +161,95 @@
 /* Define the core functions */
 #define M_PR1OQUEUE_DEF_CORE(name, type, oplist, prioqueue_t, it_t)           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(prioqueue_t p)                                             \
   {                                                                           \
     M_F(name, _array_init)(p->array);                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(prioqueue_t p, prioqueue_t const o)                    \
   {                                                                           \
     M_F(name, _array_init_set)(p->array, o->array);                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(prioqueue_t p, prioqueue_t const o)                         \
   {                                                                           \
     M_F(name, _array_set)(p->array, o->array);                                \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(prioqueue_t p)                                            \
   {                                                                           \
     M_F(name, _array_clear)(p->array);                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(prioqueue_t p, prioqueue_t o)                         \
   {                                                                           \
     M_F(name, _array_init_move)(p->array, o->array);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(prioqueue_t p, prioqueue_t o)                              \
   {                                                                           \
     M_F(name, _array_move)(p->array, o->array);                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(prioqueue_t p, prioqueue_t o)                              \
   {                                                                           \
     M_F(name, _array_swap)(p->array, o->array);                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(prioqueue_t p)                                            \
   {                                                                           \
     M_F(name, _array_reset)(p->array);                                        \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _i_parent)(size_t i)                                              \
   {                                                                           \
     M_ASSERT (i > 0);                                                         \
     return (i - 1) / 2;                                                       \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _i_lchild)(size_t i)                                              \
   {                                                                           \
     M_ASSERT(i <= ((SIZE_MAX)-2)/2);                                          \
     return 2*i + 1;                                                           \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _i_rchild)(size_t i)                                              \
   {                                                                           \
     M_ASSERT(i <= ((SIZE_MAX)-2)/2);                                          \
     return 2*i + 2;                                                           \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _i_cmp)(const prioqueue_t p, size_t i, size_t j)                  \
   {                                                                           \
     return M_CALL_CMP(oplist, *M_F(name, _array_cget)(p->array, i),           \
                       *M_F(name, _array_cget)(p->array, j));                  \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(prioqueue_t const p)                                    \
   {                                                                           \
     return M_F(name, _array_empty_p)(p->array);                               \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(prioqueue_t const p)                                       \
   {                                                                           \
     return M_F(name, _array_size)(p->array);                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push)(prioqueue_t p, type const x)                               \
   {                                                                           \
     /* Push back the new element at the end of the array */                   \
@@ -267,13 +267,13 @@
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _front)(prioqueue_t const p)                                      \
   {                                                                           \
     return M_F(name, _array_cget)(p->array, 0);                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _pop)(type *x, prioqueue_t p)                                     \
   {                                                                           \
     /* Swap the front element with the last element */                        \
@@ -303,13 +303,13 @@
   M_IF_METHOD(EQUAL, oplist)                                                  \
   (                                                                           \
     /* EQUAL & CMP may be uncorrelated */                                     \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _equal_p)(prioqueue_t const p, prioqueue_t const q)             \
     {                                                                         \
       return M_F(name, _array_equal_p)(p->array, q->array);                   \
     }                                                                         \
                                                                               \
-   static inline size_t                                                       \
+   M_INLINE size_t                                                            \
    M_F(name, _i_find)(prioqueue_t p, type const x)                            \
    {                                                                          \
      size_t size = M_F(name, _array_size)(p->array);                          \
@@ -322,7 +322,7 @@
      return i;                                                                \
    }                                                                          \
                                                                               \
-   static inline bool                                                         \
+   M_INLINE bool                                                              \
    M_F(name, _erase)(prioqueue_t p, type const x)                             \
    {                                                                          \
      /* First pass: search for an item EQUAL to x */                          \
@@ -351,7 +351,7 @@
      return true;                                                             \
    }                                                                          \
                                                                               \
-   static inline void                                                         \
+   M_INLINE void                                                              \
    M_F(name, _update)(prioqueue_t p, type const xold, type const xnew)        \
    {                                                                          \
      /* NOTE: xold can be the same pointer than xnew */                       \
@@ -394,62 +394,62 @@
 #define M_PR1OQUEUE_DEF_IT(name, type, oplist, prioqueue_t, it_t)             \
                                                                               \
   /* Define iterators over the array iterator */                              \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, prioqueue_t const v)                                \
   {                                                                           \
     M_F(name, _array_it)(it, v->array);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(it_t it, prioqueue_t const v)                           \
   {                                                                           \
     M_F(name, _array_it_last)(it, v->array);                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, prioqueue_t const v)                            \
   {                                                                           \
     M_F(name, _array_it_end)(it, v->array);                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it, const it_t org)                                 \
   {                                                                           \
     M_F(name, _array_it_set)(it, org);                                        \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     return M_F(name, _array_end_p)(it);                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _last_p)(const it_t it)                                           \
   {                                                                           \
     return M_F(name, _array_last_p)(it);                                      \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1,                                      \
                          const it_t it2)                                      \
   {                                                                           \
     return M_F(name, _array_it_equal_p)(it1, it2);                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_F(name, _array_next)(it);                                               \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(it_t it)                                               \
   {                                                                           \
     M_F(name, _array_previous)(it);                                           \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     return M_F(name, _array_cref)(it);                                        \
@@ -458,7 +458,7 @@
 /* Define the IO functions */
 #define M_PR1OQUEUE_DEF_IO(name, type, oplist, prioqueue_t, it_t)             \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, const prioqueue_t p)                        \
   {                                                                           \
     M_F(name, _array_out_str)(file, p->array);                                \
@@ -466,7 +466,7 @@
   ,/* No OUT_STR */)                                                          \
                                                                               \
   M_IF_METHOD(IN_STR, oplist)(                                                \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(prioqueue_t p, FILE *file)                               \
   {                                                                           \
     return M_F(name, _array_in_str)(p->array, file);                          \
@@ -474,7 +474,7 @@
   ,/* No IN_STR */)                                                           \
                                                                               \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(string_t str, const prioqueue_t p, bool append)         \
   {                                                                           \
     M_F(name, _array_get_str)(str, p->array, append);                         \
@@ -482,7 +482,7 @@
   ,/* No GET_STR */)                                                          \
                                                                               \
   M_IF_METHOD(PARSE_STR, oplist)(                                             \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(prioqueue_t p, const char str[], const char **endp)   \
   {                                                                           \
     return M_F(name, _array_parse_str)(p->array, str, endp);                  \
@@ -490,7 +490,7 @@
   ,/* No PARSE_STR */)                                                        \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, const prioqueue_t p)             \
   {                                                                           \
     return M_F(name, _array_out_serial)(f, p->array);                         \
@@ -498,7 +498,7 @@
   ,/* No OUT_SERIAL */)                                                       \
                                                                               \
   M_IF_METHOD2(IN_SERIAL, INIT, oplist)(                                      \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(prioqueue_t p, m_serial_read_t f)                     \
   {                                                                           \
     return M_F(name, _array_in_serial)(p->array, f);                          \

--- a/m-rbtree.h
+++ b/m-rbtree.h
@@ -224,28 +224,28 @@ typedef enum {
     /* Definition of the global variable used to reference this pool */       \
     M_GET_MEMPOOL_LINKAGE oplist M_F(name, _mempool_t) M_GET_MEMPOOL oplist;  \
     /* Allocator function */                                                  \
-    static inline node_t *M_C3(m_rbtr33_,name,_new)(void) {                   \
+    M_INLINE node_t *M_C3(m_rbtr33_,name,_new)(void) {                        \
       return M_F(name, _mempool_alloc)(M_GET_MEMPOOL oplist);                 \
     }                                                                         \
     /* Deallocator function */                                                \
-    static inline void M_C3(m_rbtr33_,name,_del)(node_t *ptr) {               \
+    M_INLINE void M_C3(m_rbtr33_,name,_del)(node_t *ptr) {                    \
       M_F(name, _mempool_free)(M_GET_MEMPOOL oplist, ptr);                    \
     }                                                                         \
                                                                               \
     , /* No mempool allocation */                                             \
     /* Classic Allocator function (common case) */                            \
-    static inline node_t *M_C3(m_rbtr33_,name,_new)(void) {                   \
+    M_INLINE node_t *M_C3(m_rbtr33_,name,_new)(void) {                        \
       return M_CALL_NEW(oplist, node_t);                                      \
     }                                                                         \
     /* Classic deallocator function (common case) */                          \
-    static inline void M_C3(m_rbtr33_,name,_del)(node_t *ptr) {               \
+    M_INLINE void M_C3(m_rbtr33_,name,_del)(node_t *ptr) {                    \
       M_CALL_DEL(oplist, ptr);                                                \
     }                                                                 )       \
 
 /* Define the core functions */
 #define M_RBTR33_DEF_CORE(name, type, oplist, tree_t, node_t, it_t)           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(tree_t tree)                                               \
   {                                                                           \
     M_ASSERT (tree != NULL);                                                  \
@@ -254,7 +254,7 @@ typedef enum {
     M_RBTR33_CONTRACT(tree);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(tree_t tree)                                              \
   {                                                                           \
     M_RBTR33_CONTRACT(tree);                                                  \
@@ -299,14 +299,14 @@ typedef enum {
     tree->size = 0;                                                           \
    }                                                                          \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(tree_t tree)                                              \
   {                                                                           \
     /* Nothing more than clean the tree as everything is cleared */           \
     M_F(name, _reset)(tree);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _push)(tree_t tree, type const data)                              \
   {                                                                           \
     M_RBTR33_CONTRACT(tree);                                                  \
@@ -432,7 +432,7 @@ typedef enum {
     M_RBTR33_CONTRACT (tree);                                                 \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const tree_t tree)                                         \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -440,7 +440,7 @@ typedef enum {
   }                                                                           \
                                                                               \
   /* Set the iterator to the first (child=0) or last (child=1) element */     \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_rbtr33_,name,_it)(it_t it, const tree_t tree, int child)             \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -462,19 +462,19 @@ typedef enum {
     it->cpt = cpt;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, const tree_t tree)                                  \
   {                                                                           \
     M_C3(m_rbtr33_,name,_it)(it, tree, 0);                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_last)(it_t it, const tree_t tree)                             \
   {                                                                           \
     M_C3(m_rbtr33_,name,_it)(it, tree, 1);                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_end)(it_t it, const tree_t tree)                              \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -483,14 +483,14 @@ typedef enum {
     it->cpt = 0;                                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t it, const it_t ref)                                 \
   {                                                                           \
     M_ASSERT (it != NULL && ref != NULL);                                     \
     *it = *ref;                                                               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(const it_t it)                                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -498,7 +498,7 @@ typedef enum {
   }                                                                           \
                                                                               \
   /* Go to the next (child = 0)or previous element (child = 1) */             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_rbtr33_,name,_next)(it_t it, int child)                              \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -530,19 +530,19 @@ typedef enum {
     it->cpt = cpt;                                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _next)(it_t it)                                                   \
   {                                                                           \
     M_C3(m_rbtr33_,name,_next)(it, 0);                                        \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _previous)(it_t it)                                               \
   {                                                                           \
     M_C3(m_rbtr33_,name,_next)(it, 1);                                        \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(const it_t it)                                              \
   {                                                                           \
     M_ASSERT(it != NULL);                                                     \
@@ -552,13 +552,13 @@ typedef enum {
     return &(it->stack[it->cpt-1]->data);                                     \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const it_t it)                                             \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _ref)(it));                           \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_equal_p)(const it_t it1, const it_t it2)                      \
   {                                                                           \
     M_ASSERT(it1 != NULL && it2 != NULL);                                     \
@@ -569,7 +569,7 @@ typedef enum {
       && (it1->cpt == 0 || it1->stack[it1->cpt-1] == it2->stack[it2->cpt-1]); \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_from)(it_t it, const tree_t tree, type const data)            \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -598,7 +598,7 @@ typedef enum {
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_until_p)(it_t it, type const data)                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -609,7 +609,7 @@ typedef enum {
     return (cmp >= 0);                                                        \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _it_while_p)(it_t it, type const data)                            \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
@@ -620,7 +620,7 @@ typedef enum {
     return (cmp <= 0);                                                        \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _min)(const tree_t tree)                                          \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -633,7 +633,7 @@ typedef enum {
     return &n->data;                                                          \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _max)(const tree_t tree)                                          \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -646,19 +646,19 @@ typedef enum {
     return &n->data;                                                          \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cmin)(const tree_t tree)                                         \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _min)(tree));                         \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cmax)(const tree_t tree)                                         \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _max)(tree));                         \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _get)(const tree_t tree, type const data)                         \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -677,14 +677,14 @@ typedef enum {
     return NULL;                                                              \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cget)(const tree_t tree, type const data)                        \
   {                                                                           \
     return M_CONST_CAST(type, M_F(name, _get)(tree, data));                   \
   }                                                                           \
                                                                               \
   /* Create a copy of the given node (recursively) */                         \
-  static inline node_t *                                                      \
+  M_INLINE node_t *                                                           \
   M_C3(m_rbtr33_,name,_copy_node)(const node_t *o)                            \
   {                                                                           \
     if (o == NULL) return NULL;                                               \
@@ -700,7 +700,7 @@ typedef enum {
     return n;                                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(tree_t tree, const tree_t ref)                         \
   {                                                                           \
     M_RBTR33_CONTRACT (ref);                                                  \
@@ -711,7 +711,7 @@ typedef enum {
     M_RBTR33_CONTRACT (tree);                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(tree_t tree, const tree_t ref)                              \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -721,7 +721,7 @@ typedef enum {
     M_F(name,_init_set)(tree, ref);                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(tree_t tree, tree_t ref)                              \
   {                                                                           \
     M_RBTR33_CONTRACT (ref);                                                  \
@@ -733,7 +733,7 @@ typedef enum {
     M_RBTR33_CONTRACT (tree);                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(tree_t tree, tree_t ref)                                   \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -744,7 +744,7 @@ typedef enum {
     M_RBTR33_CONTRACT (tree);                                                 \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(tree_t tree1, tree_t tree2)                                \
   {                                                                           \
     M_RBTR33_CONTRACT (tree1);                                                \
@@ -755,7 +755,7 @@ typedef enum {
     M_RBTR33_CONTRACT (tree2);                                                \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const tree_t tree)                                      \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -763,19 +763,19 @@ typedef enum {
   }                                                                           \
                                                                               \
   /* Take care of the case n == NULL too */                                   \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C3(m_rbtr33_,name,_black_p)(const node_t *n)                              \
   {                                                                           \
     return (n == NULL) ? true : M_RBTR33_IS_BLACK(n);                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_rbtr33_,name,_set_black)(node_t *n)                                  \
   {                                                                           \
     if (n != NULL) M_RBTR33_SET_BLACK(n);                                     \
   }                                                                           \
                                                                               \
-  static inline node_t *                                                      \
+  M_INLINE node_t *                                                           \
   M_C3(m_rbtr33_,name,_rotate)(node_t *pp, node_t *ppp, const bool right)     \
   {                                                                           \
     M_ASSERT (pp != NULL && ppp != NULL);                                     \
@@ -792,7 +792,7 @@ typedef enum {
                                                                               \
   M_IF_DEBUG(                                                                 \
   /* Compute the depth of a node */                                           \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_C3(m_rbtr33_,name,_compute_depth)(const node_t *n)                        \
   {                                                                           \
     if (n == NULL) return 1;                                                  \
@@ -801,7 +801,7 @@ typedef enum {
   }                                                                           \
   )                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _pop_at)(type *data_ptr, tree_t tree, type const key)             \
   {                                                                           \
     M_RBTR33_CONTRACT (tree);                                                 \
@@ -961,7 +961,7 @@ typedef enum {
     return true;                                                              \
   }                                                                           \
                                                                               \
-  static inline void M_F(name,_remove)(tree_t t, it_t it)                     \
+  M_INLINE void M_F(name,_remove)(tree_t t, it_t it)                          \
   {                                                                           \
     /* Not optimum: another search in the tree is performed */                \
     type data;                                                                \
@@ -976,7 +976,7 @@ typedef enum {
   }                                                                           \
                                                                               \
   M_IF_METHOD(EQUAL, oplist)(                                                 \
-  static inline bool M_F(name,_equal_p)(const tree_t t1, const tree_t t2) {   \
+  M_INLINE bool M_F(name,_equal_p)(const tree_t t1, const tree_t t2) {        \
     M_RBTR33_CONTRACT(t1);                                                    \
     M_RBTR33_CONTRACT(t2);                                                    \
     if (t1->size != t2->size) return false;                                   \
@@ -1003,7 +1003,7 @@ typedef enum {
   , /* NO EQUAL METHOD */ )                                                   \
                                                                               \
   M_IF_METHOD(HASH, oplist)(                                                  \
-  static inline size_t M_F(name,_hash)(const tree_t t1) {                     \
+  M_INLINE size_t M_F(name,_hash)(const tree_t t1) {                          \
     M_RBTR33_CONTRACT(t1);                                                    \
     M_HASH_DECL(hash);                                                        \
     /* NOTE: We can't compute the hash directly for the same reason           \
@@ -1022,7 +1022,7 @@ typedef enum {
 /* Define the I/O functions */
 #define M_RBTR33_DEF_IO(name, type, oplist, tree_t, node_t, it_t)             \
   M_IF_METHOD(GET_STR, oplist)(                                               \
-  static inline void M_F(name, _get_str)(m_string_t str,                      \
+  M_INLINE void M_F(name, _get_str)(m_string_t str,                           \
                                          tree_t const t1, bool append) {      \
     M_RBTR33_CONTRACT(t1);                                                    \
     M_ASSERT(str != NULL);                                                    \
@@ -1044,7 +1044,7 @@ typedef enum {
   , /* NO GET_STR */ )                                                        \
                                                                               \
   M_IF_METHOD(OUT_STR, oplist)(                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *file, tree_t const rbtree)                        \
   {                                                                           \
     M_RBTR33_CONTRACT(rbtree);                                                \
@@ -1066,7 +1066,7 @@ typedef enum {
   , /* no out_str */ )                                                        \
                                                                               \
   M_IF_METHOD(PARSE_STR, oplist)(                                             \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(tree_t rbtree, const char str[], const char **endp)   \
   {                                                                           \
     M_RBTR33_CONTRACT(rbtree);                                                \
@@ -1097,7 +1097,7 @@ typedef enum {
   , /* no parse_str */ )                                                      \
                                                                               \
   M_IF_METHOD(IN_STR, oplist)(                                                \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(tree_t rbtree, FILE *file)                               \
   {                                                                           \
     M_RBTR33_CONTRACT(rbtree);                                                \
@@ -1123,7 +1123,7 @@ typedef enum {
   , /* no in_str */ )                                                         \
                                                                               \
   M_IF_METHOD(OUT_SERIAL, oplist)(                                            \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f, tree_t const t1)                 \
   {                                                                           \
     M_RBTR33_CONTRACT(t1);                                                    \
@@ -1149,7 +1149,7 @@ typedef enum {
   , /* no OUT_SERIAL */ )                                                     \
                                                                               \
   M_IF_METHOD(IN_SERIAL, oplist)(                                             \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(tree_t t1, m_serial_read_t f)                         \
   {                                                                           \
     M_RBTR33_CONTRACT(t1);                                                    \

--- a/m-serial-bin.h
+++ b/m-serial-bin.h
@@ -41,7 +41,7 @@ M_BEGIN_PROTECTED_CODE
  * Write size_t in the stream in a compact form to reduce consumption
  * (and I/O bandwidth)
  */
-static inline bool
+M_INLINE bool
 m_ser1al_bin_write_size(FILE *f, const size_t size)
 {
   bool b;
@@ -88,7 +88,7 @@ m_ser1al_bin_write_size(FILE *f, const size_t size)
  * Read size_t in the stream from a compact form to reduce consumption
  * (and I/O bandwidth)
  */
-static inline bool
+M_INLINE bool
 m_ser1al_bin_read_size(FILE *f, size_t *size)
 {
   int c;
@@ -111,7 +111,7 @@ m_ser1al_bin_read_size(FILE *f, size_t *size)
 
 /* Write the boolean 'data' into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_bin_write_boolean(m_serial_write_t serial, const bool data)
 {
   FILE *f = (FILE *)serial->data[0].p;
@@ -121,7 +121,7 @@ m_ser1al_bin_write_boolean(m_serial_write_t serial, const bool data)
 
 /* Write the integer 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_bin_write_integer(m_serial_write_t serial,const long long data, const size_t size_of_type)
 {
   size_t n;
@@ -146,7 +146,7 @@ m_ser1al_bin_write_integer(m_serial_write_t serial,const long long data, const s
 
 /* Write the float 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_bin_write_float(m_serial_write_t serial, const long double data, const size_t size_of_type)
 {
   size_t n;
@@ -168,7 +168,7 @@ m_ser1al_bin_write_float(m_serial_write_t serial, const long double data, const 
 
 /* Write the null-terminated string 'data'into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_bin_write_string(m_serial_write_t serial, const char data[], size_t length)
 {
   M_ASSERT_SLOW(length == strlen(data) );
@@ -188,7 +188,7 @@ m_ser1al_bin_write_string(m_serial_write_t serial, const char data[], size_t len
    Initialize 'local' so that it can be used to serialize the array 
    (local is an unique serialization object of the array).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_bin_write_array_start(m_serial_local_t local, m_serial_write_t serial, const size_t number_of_elements)
 {
   (void) local; //Unused
@@ -200,7 +200,7 @@ m_ser1al_bin_write_array_start(m_serial_local_t local, m_serial_write_t serial, 
 
 /* Write an array separator between elements of an array into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_write_array_next(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // Unused
@@ -210,7 +210,7 @@ m_ser1al_bin_write_array_next(m_serial_local_t local, m_serial_write_t serial)
 
 /* End the writing of an array into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_array_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // Unused
@@ -220,7 +220,7 @@ m_ser1al_bin_write_array_end(m_serial_local_t local, m_serial_write_t serial)
 
 /* Write a value separator between element of the same pair of a map into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_map_value(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -232,7 +232,7 @@ m_ser1al_bin_write_map_value(m_serial_local_t local, m_serial_write_t serial)
    Initialize 'local' so that it can serial the tuple 
    (local is an unique serialization object of the tuple).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_tuple_start(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -242,7 +242,7 @@ m_ser1al_bin_write_tuple_start(m_serial_local_t local, m_serial_write_t serial)
 
 /* Start writing the field named field_name[index] of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_tuple_id(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) local; // argument not used
@@ -255,7 +255,7 @@ m_ser1al_bin_write_tuple_id(m_serial_local_t local, m_serial_write_t serial, con
 
 /* End the write of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_tuple_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -268,7 +268,7 @@ m_ser1al_bin_write_tuple_end(m_serial_local_t local, m_serial_write_t serial)
      Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise 
    Otherwise, the field 'field_name[index]' will be filled.
      Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_variant_start(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) field_name;
@@ -281,7 +281,7 @@ m_ser1al_bin_write_variant_start(m_serial_local_t local, m_serial_write_t serial
 
 /* End Writing a variant into the serial stream 'serial'. 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_bin_write_variant_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -309,13 +309,13 @@ static const m_serial_write_interface_t m_ser1al_bin_write_interface = {
   m_ser1al_bin_write_variant_end
 };
 
-static inline void m_serial_bin_write_init(m_serial_write_t serial, FILE *f)
+M_INLINE void m_serial_bin_write_init(m_serial_write_t serial, FILE *f)
 {
   serial->m_interface = &m_ser1al_bin_write_interface;
   serial->data[0].p = M_ASSIGN_CAST(void*, f);
 }
 
-static inline void m_serial_bin_write_clear(m_serial_write_t serial)
+M_INLINE void m_serial_bin_write_clear(m_serial_write_t serial)
 {
   (void) serial; // Nothing to do
 }
@@ -337,7 +337,7 @@ typedef m_serial_write_t m_serial_bin_write_t;
 /* Read from the stream 'serial' a boolean.
    Set '*b' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_boolean(m_serial_read_t serial, bool *b){
   FILE *f = (FILE*) serial->data[0].p;
   size_t n = fread (M_ASSIGN_CAST(void*, b), sizeof (bool), 1, f);
@@ -347,7 +347,7 @@ m_ser1al_bin_read_boolean(m_serial_read_t serial, bool *b){
 /* Read from the stream 'serial' an integer that can be represented with 'size_of_type' bytes.
    Set '*i' with the integer value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_integer(m_serial_read_t serial, long long *i, const size_t size_of_type){
   int8_t   i8;
   int16_t i16;
@@ -375,7 +375,7 @@ m_ser1al_bin_read_integer(m_serial_read_t serial, long long *i, const size_t siz
 /* Read from the stream 'serial' a float that can be represented with 'size_of_type' bytes.
    Set '*r' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_float(m_serial_read_t serial, long double *r, const size_t size_of_type){
   float   f1;
   double  f2;
@@ -399,7 +399,7 @@ m_ser1al_bin_read_float(m_serial_read_t serial, long double *r, const size_t siz
 /* Read from the stream 'serial' a string.
    Set 's' with the string if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_string(m_serial_read_t serial, struct string_s *s){
   FILE *f = (FILE*) serial->data[0].p;
   M_ASSERT(f != NULL && s != NULL);
@@ -424,7 +424,7 @@ m_ser1al_bin_read_string(m_serial_read_t serial, struct string_s *s){
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends (the array is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_array_start(m_serial_local_t local, m_serial_read_t serial, size_t *num)
 {
   FILE *f = (FILE*) serial->data[0].p;
@@ -437,7 +437,7 @@ m_ser1al_bin_read_array_start(m_serial_local_t local, m_serial_read_t serial, si
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_array_next(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) serial; // Unused
@@ -450,7 +450,7 @@ m_ser1al_bin_read_array_next(m_serial_local_t local, m_serial_read_t serial)
 /* Continue reading from the stream 'serial' the value separator
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_map_value(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -461,7 +461,7 @@ m_ser1al_bin_read_map_value(m_serial_local_t local, m_serial_read_t serial)
 /* Start reading a tuple from the stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_tuple_start(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) serial;
@@ -475,7 +475,7 @@ m_ser1al_bin_read_tuple_start(m_serial_local_t local, m_serial_read_t serial)
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    Return M_SERIAL_OK_DONE if it succeeds and the tuple ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, const char *const field_name [], const int max, int *id)
 {
   (void) serial;
@@ -492,7 +492,7 @@ m_ser1al_bin_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, const
    Return M_SERIAL_OK_CONTINUE if it succeeds and the variant continues,
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends(variant is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_variant_start(m_serial_local_t local, m_serial_read_t serial, const char *const field_name[], const int max, int*id)
 {
   (void) field_name;
@@ -506,7 +506,7 @@ m_ser1al_bin_read_variant_start(m_serial_local_t local, m_serial_read_t serial, 
 /* End reading a variant from the stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_bin_read_variant_end(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -530,13 +530,13 @@ static const m_serial_read_interface_t m_ser1al_bin_read_interface = {
   m_ser1al_bin_read_variant_end
 };
 
-static inline void m_serial_bin_read_init(m_serial_read_t serial, FILE *f)
+M_INLINE void m_serial_bin_read_init(m_serial_read_t serial, FILE *f)
 {
   serial->m_interface = &m_ser1al_bin_read_interface;
   serial->data[0].p = M_ASSIGN_CAST(void*, f);
 }
 
-static inline void m_serial_bin_read_clear(m_serial_read_t serial)
+M_INLINE void m_serial_bin_read_clear(m_serial_read_t serial)
 {
   (void) serial; // Nothing to do
 }

--- a/m-serial-json.h
+++ b/m-serial-json.h
@@ -36,7 +36,7 @@ M_BEGIN_PROTECTED_CODE
 
 /* Write the boolean 'data' into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_json_write_boolean(m_serial_write_t serial, const bool data)
 {
   FILE *f = (FILE *)serial->data[0].p;
@@ -46,7 +46,7 @@ m_ser1al_json_write_boolean(m_serial_write_t serial, const bool data)
 
 /* Write the integer 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_json_write_integer(m_serial_write_t serial,const long long data, const size_t size_of_type)
 {
   (void) size_of_type; // Ignored
@@ -57,7 +57,7 @@ m_ser1al_json_write_integer(m_serial_write_t serial,const long long data, const 
 
 /* Write the float 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_json_write_float(m_serial_write_t serial, const long double data, const size_t size_of_type)
 {
   (void) size_of_type; // Ignored
@@ -68,7 +68,7 @@ m_ser1al_json_write_float(m_serial_write_t serial, const long double data, const
 
 /* Write the null-terminated string 'data'into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_json_write_string(m_serial_write_t serial, const char data[], size_t length)
 {
   M_ASSERT_SLOW(length == strlen(data) );
@@ -90,7 +90,7 @@ m_ser1al_json_write_string(m_serial_write_t serial, const char data[], size_t le
    Initialize 'local' so that it can be used to serialize the array 
    (local is an unique serialization object of the array).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_json_write_array_start(m_serial_local_t local, m_serial_write_t serial, const size_t number_of_elements)
 {
   (void) local; // argument not used
@@ -102,7 +102,7 @@ m_ser1al_json_write_array_start(m_serial_local_t local, m_serial_write_t serial,
 
 /* Write an array separator between elements of an array into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_write_array_next(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -113,7 +113,7 @@ m_ser1al_json_write_array_next(m_serial_local_t local, m_serial_write_t serial)
 
 /* End the writing of an array into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_array_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -128,7 +128,7 @@ m_ser1al_json_write_array_end(m_serial_local_t local, m_serial_write_t serial)
    Initialize 'local' so that it can be used to serialize the map 
    (local is an unique serialization object of the map).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_map_start(m_serial_local_t local, m_serial_write_t serial, const size_t number_of_elements)
 {
   (void) local; // argument not used
@@ -140,7 +140,7 @@ m_ser1al_json_write_map_start(m_serial_local_t local, m_serial_write_t serial, c
 
 /* Write a value separator between element of the same pair of a map into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_map_value(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -151,7 +151,7 @@ m_ser1al_json_write_map_value(m_serial_local_t local, m_serial_write_t serial)
 
 /* Write a map separator between elements of a map into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_map_next(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -162,7 +162,7 @@ m_ser1al_json_write_map_next(m_serial_local_t local, m_serial_write_t serial)
 
 /* End the writing of a map into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_map_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -175,7 +175,7 @@ m_ser1al_json_write_map_end(m_serial_local_t local, m_serial_write_t serial)
    Initialize 'local' so that it can serial the tuple 
    (local is an unique serialization object of the tuple).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_tuple_start(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -186,7 +186,7 @@ m_ser1al_json_write_tuple_start(m_serial_local_t local, m_serial_write_t serial)
 
 /* Start writing the field named field_name[index] of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_tuple_id(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) local; // argument not used
@@ -198,7 +198,7 @@ m_ser1al_json_write_tuple_id(m_serial_local_t local, m_serial_write_t serial, co
 
 /* End the write of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_tuple_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -212,7 +212,7 @@ m_ser1al_json_write_tuple_end(m_serial_local_t local, m_serial_write_t serial)
      Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise 
    Otherwise, the field 'field_name[index]' will be filled.
      Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_variant_start(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) local; // argument not used
@@ -231,7 +231,7 @@ m_ser1al_json_write_variant_start(m_serial_local_t local, m_serial_write_t seria
 
 /* End Writing a variant into the serial stream 'serial'. 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_json_write_variant_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -262,14 +262,14 @@ static const m_serial_write_interface_t m_ser1al_json_write_interface = {
 };
 
 /* Initialize the JSON serial object for writing any object to JSON format in the given FILE */
-static inline void m_serial_json_write_init(m_serial_write_t serial, FILE *f)
+M_INLINE void m_serial_json_write_init(m_serial_write_t serial, FILE *f)
 {
   serial->m_interface = &m_ser1al_json_write_interface;
   serial->data[0].p = M_ASSIGN_CAST(void*, f);
 }
 
 /* CLear the JSON serial object for writing*/
-static inline void m_serial_json_write_clear(m_serial_write_t serial)
+M_INLINE void m_serial_json_write_clear(m_serial_write_t serial)
 {
   (void) serial; // Nothing to do
 }
@@ -288,7 +288,7 @@ typedef m_serial_write_t m_serial_json_write_t;
 /********************************************************************************/
 
 /* Helper function to skip a space */
-static inline int
+M_INLINE int
 m_ser1al_json_read_skip (FILE *f)
 {
   int c;
@@ -302,7 +302,7 @@ m_ser1al_json_read_skip (FILE *f)
 /* Read from the stream 'serial' a boolean.
    Set '*b' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_boolean(m_serial_read_t serial, bool *b){
   FILE *f = (FILE*) serial->data[0].p;
   int c = m_ser1al_json_read_skip(f);
@@ -334,7 +334,7 @@ m_ser1al_json_read_boolean(m_serial_read_t serial, bool *b){
 /* Read from the stream 'serial' an integer that can be represented with 'size_of_type' bytes.
    Set '*i' with the integer value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_integer(m_serial_read_t serial, long long *i, const size_t size_of_type){
   (void) size_of_type; // Ignored
   FILE *f = (FILE*) serial->data[0].p;
@@ -344,7 +344,7 @@ m_ser1al_json_read_integer(m_serial_read_t serial, long long *i, const size_t si
 /* Read from the stream 'serial' a float that can be represented with 'size_of_type' bytes.
    Set '*r' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_float(m_serial_read_t serial, long double *r, const size_t size_of_type){
   (void) size_of_type; // Ignored
   FILE *f = (FILE*) serial->data[0].p;
@@ -354,7 +354,7 @@ m_ser1al_json_read_float(m_serial_read_t serial, long double *r, const size_t si
 /* Read from the stream 'serial' a string.
    Set 's' with the string if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_string(m_serial_read_t serial, struct m_string_s *s){
   FILE *f = (FILE*) serial->data[0].p;
   int n = m_core_fscanf(f, " "); // Skip any leading spaces.
@@ -369,7 +369,7 @@ m_ser1al_json_read_string(m_serial_read_t serial, struct m_string_s *s){
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends (the array is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_array_start(m_serial_local_t local, m_serial_read_t serial, size_t *num)
 {
   (void) local; // argument not used
@@ -387,7 +387,7 @@ m_ser1al_json_read_array_start(m_serial_local_t local, m_serial_read_t serial, s
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_array_next(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -405,7 +405,7 @@ m_ser1al_json_read_array_next(m_serial_local_t local, m_serial_read_t serial)
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_OK_DONE if it succeeds and the map ends (the map is empty),
    m_core_serial_fail() otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_map_start(m_serial_local_t local, m_serial_read_t serial, size_t *num)
 {
   (void) local; // argument not used
@@ -422,7 +422,7 @@ m_ser1al_json_read_map_start(m_serial_local_t local, m_serial_read_t serial, siz
 /* Continue reading from the stream 'serial' the value separator
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_map_value(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -437,7 +437,7 @@ m_ser1al_json_read_map_value(m_serial_local_t local, m_serial_read_t serial)
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_OK_DONE if it succeeds and the map ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_map_next(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -451,7 +451,7 @@ m_ser1al_json_read_map_next(m_serial_local_t local, m_serial_read_t serial)
 /* Start reading a tuple from the stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_tuple_start(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -468,7 +468,7 @@ m_ser1al_json_read_tuple_start(m_serial_local_t local, m_serial_read_t serial)
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    Return M_SERIAL_OK_DONE if it succeeds and the tuple ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, const char *const field_name [], const int max, int *id)
 {
   (void) local; // argument not used
@@ -507,7 +507,7 @@ m_ser1al_json_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, cons
    Return M_SERIAL_OK_CONTINUE if it succeeds and the variant continues,
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends(variant is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_variant_start(m_serial_local_t local, m_serial_read_t serial, const char *const field_name[], const int max, int*id)
 {
   (void) local; // argument not used
@@ -542,7 +542,7 @@ m_ser1al_json_read_variant_start(m_serial_local_t local, m_serial_read_t serial,
 /* End reading a variant from the stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_json_read_variant_end(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -570,14 +570,14 @@ static const m_serial_read_interface_t m_ser1al_json_read_interface = {
 };
 
 /* Initialize the JSON serial object for reading any object from JSON format in the given FILE */
-static inline void m_serial_json_read_init(m_serial_read_t serial, FILE *f)
+M_INLINE void m_serial_json_read_init(m_serial_read_t serial, FILE *f)
 {
   serial->m_interface = &m_ser1al_json_read_interface;
   serial->data[0].p = M_ASSIGN_CAST(void*, f);
 }
 
 /* Clear the JSON serial object for reading from the FILE */
-static inline void m_serial_json_read_clear(m_serial_read_t serial)
+M_INLINE void m_serial_json_read_clear(m_serial_read_t serial)
 {
   (void) serial; // Nothing to do
 }
@@ -597,7 +597,7 @@ typedef m_serial_read_t m_serial_json_read_t;
 
 /* Write the boolean 'data' into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_str_json_write_boolean(m_serial_write_t serial, const bool data)
 {
   struct m_string_s *f = (struct m_string_s *)serial->data[0].p;
@@ -607,7 +607,7 @@ m_ser1al_str_json_write_boolean(m_serial_write_t serial, const bool data)
 
 /* Write the integer 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_str_json_write_integer(m_serial_write_t serial,const long long data, const size_t size_of_type)
 {
   (void) size_of_type; // Ignored
@@ -618,7 +618,7 @@ m_ser1al_str_json_write_integer(m_serial_write_t serial,const long long data, co
 
 /* Write the float 'data' of 'size_of_type' bytes into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_str_json_write_float(m_serial_write_t serial, const long double data, const size_t size_of_type)
 {
   (void) size_of_type; // Ignored
@@ -629,7 +629,7 @@ m_ser1al_str_json_write_float(m_serial_write_t serial, const long double data, c
 
 /* Write the null-terminated string 'data'into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_str_json_write_string(m_serial_write_t serial, const char data[], size_t length)
 {
   M_ASSERT_SLOW(length == strlen(data) );
@@ -651,7 +651,7 @@ m_ser1al_str_json_write_string(m_serial_write_t serial, const char data[], size_
    Initialize 'local' so that it can be used to serialize the array 
    (local is an unique serialization object of the array).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_ser1al_str_json_write_array_start(m_serial_local_t local, m_serial_write_t serial, const size_t number_of_elements)
 {
   (void) local; // argument not used
@@ -663,7 +663,7 @@ m_ser1al_str_json_write_array_start(m_serial_local_t local, m_serial_write_t ser
 
 /* Write an array separator between elements of an array into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_write_array_next(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -674,7 +674,7 @@ m_ser1al_str_json_write_array_next(m_serial_local_t local, m_serial_write_t seri
 
 /* End the writing of an array into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_array_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -689,7 +689,7 @@ m_ser1al_str_json_write_array_end(m_serial_local_t local, m_serial_write_t seria
    Initialize 'local' so that it can be used to serialize the map 
    (local is an unique serialization object of the map).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_map_start(m_serial_local_t local, m_serial_write_t serial, const size_t number_of_elements)
 {
   (void) local; // argument not used
@@ -701,7 +701,7 @@ m_ser1al_str_json_write_map_start(m_serial_local_t local, m_serial_write_t seria
 
 /* Write a value separator between element of the same pair of a map into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_map_value(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -712,7 +712,7 @@ m_ser1al_str_json_write_map_value(m_serial_local_t local, m_serial_write_t seria
 
 /* Write a map separator between elements of a map into the serial stream 'serial' if needed.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_map_next(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -723,7 +723,7 @@ m_ser1al_str_json_write_map_next(m_serial_local_t local, m_serial_write_t serial
 
 /* End the writing of a map into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_map_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -736,7 +736,7 @@ m_ser1al_str_json_write_map_end(m_serial_local_t local, m_serial_write_t serial)
    Initialize 'local' so that it can serial the tuple 
    (local is an unique serialization object of the tuple).
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_tuple_start(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -747,7 +747,7 @@ m_ser1al_str_json_write_tuple_start(m_serial_local_t local, m_serial_write_t ser
 
 /* Start writing the field named field_name[index] of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_tuple_id(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) local; // argument not used
@@ -759,7 +759,7 @@ m_ser1al_str_json_write_tuple_id(m_serial_local_t local, m_serial_write_t serial
 
 /* End the write of a tuple into the serial stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_tuple_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -773,7 +773,7 @@ m_ser1al_str_json_write_tuple_end(m_serial_local_t local, m_serial_write_t seria
      Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise 
    Otherwise, the field 'field_name[index]' will be filled.
      Return M_SERIAL_OK_CONTINUE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_variant_start(m_serial_local_t local, m_serial_write_t serial, const char *const field_name[], const int max, const int index)
 {
   (void) local; // argument not used
@@ -792,7 +792,7 @@ m_ser1al_str_json_write_variant_start(m_serial_local_t local, m_serial_write_t s
 
 /* End Writing a variant into the serial stream 'serial'. 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline   m_serial_return_code_t
+M_INLINE   m_serial_return_code_t
 m_ser1al_str_json_write_variant_end(m_serial_local_t local, m_serial_write_t serial)
 {
   (void) local; // argument not used
@@ -822,14 +822,14 @@ static const m_serial_write_interface_t m_ser1al_str_json_write_interface = {
 };
 
 /* Initialize the JSON serial object for writing any object to JSON format in the given FILE */
-static inline void m_serial_str_json_write_init(m_serial_write_t serial, m_string_t s)
+M_INLINE void m_serial_str_json_write_init(m_serial_write_t serial, m_string_t s)
 {
   serial->m_interface = &m_ser1al_str_json_write_interface;
   serial->data[0].p = M_ASSIGN_CAST(struct m_string_s *, s);
 }
 
 /* CLear the JSON serial object for writing*/
-static inline void m_serial_str_json_write_clear(m_serial_write_t serial)
+M_INLINE void m_serial_str_json_write_clear(m_serial_write_t serial)
 {
   (void) serial; // Nothing to do
 }
@@ -847,7 +847,7 @@ typedef m_serial_write_t m_serial_str_json_write_t;
 /********************************************************************************/
 
 /* Helper function to read a character and advance the stream */
-static inline char
+M_INLINE char
 m_ser1al_str_json_getc(const char **p)
 {
   char c = **p;
@@ -857,7 +857,7 @@ m_ser1al_str_json_getc(const char **p)
 }
 
 /* Helper function to skip space(s) */
-static inline void
+M_INLINE void
 m_ser1al_str_json_skip (const char **p)
 {
   while (isspace (**p)) {
@@ -866,7 +866,7 @@ m_ser1al_str_json_skip (const char **p)
 }
 
 /* Helper function to read a string with characters not present in reject */
-static inline void
+M_INLINE void
 m_ser1al_str_json_gets(size_t alloc, char field[], const char reject[], const char **s)
 {
   M_ASSERT (alloc > 0);
@@ -881,7 +881,7 @@ m_ser1al_str_json_gets(size_t alloc, char field[], const char reject[], const ch
 /* Read from the stream 'serial' a boolean.
    Set '*b' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_boolean(m_serial_read_t serial, bool *b){
   const char **f = &serial->data[0].cstr;
   m_ser1al_str_json_skip(f);
@@ -914,7 +914,7 @@ m_ser1al_str_json_read_boolean(m_serial_read_t serial, bool *b){
 /* Read from the stream 'serial' an integer that can be represented with 'size_of_type' bytes.
    Set '*i' with the integer value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_integer(m_serial_read_t serial, long long *i, const size_t size_of_type){
   (void) size_of_type; // Ignored
   const char **f = &serial->data[0].cstr;
@@ -928,7 +928,7 @@ m_ser1al_str_json_read_integer(m_serial_read_t serial, long long *i, const size_
 /* Read from the stream 'serial' a float that can be represented with 'size_of_type' bytes.
    Set '*r' with the boolean value if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_float(m_serial_read_t serial, long double *r, const size_t size_of_type){
   (void) size_of_type; // Ignored
   const char **f = &serial->data[0].cstr;
@@ -942,7 +942,7 @@ m_ser1al_str_json_read_float(m_serial_read_t serial, long double *r, const size_
 /* Read from the stream 'serial' a string.
    Set 's' with the string if succeeds 
    Return M_SERIAL_OK_DONE if it succeeds, M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_string(m_serial_read_t serial, struct m_string_s *s){
   const char **f = &serial->data[0].cstr;
   m_ser1al_str_json_skip(f);
@@ -959,7 +959,7 @@ m_ser1al_str_json_read_string(m_serial_read_t serial, struct m_string_s *s){
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends (the array is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_array_start(m_serial_local_t local, m_serial_read_t serial, size_t *num)
 {
   (void) local; // argument not used
@@ -984,7 +984,7 @@ m_ser1al_str_json_read_array_start(m_serial_local_t local, m_serial_read_t seria
    Return M_SERIAL_OK_CONTINUE if it succeeds and the array continue,
    M_SERIAL_OK_DONE if it succeeds and the array ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_array_next(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -1001,7 +1001,7 @@ m_ser1al_str_json_read_array_next(m_serial_local_t local, m_serial_read_t serial
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_OK_DONE if it succeeds and the map ends (the map is empty),
    m_core_serial_fail() otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_map_start(m_serial_local_t local, m_serial_read_t serial, size_t *num)
 {
   (void) local; // argument not used
@@ -1025,7 +1025,7 @@ m_ser1al_str_json_read_map_start(m_serial_local_t local, m_serial_read_t serial,
 /* Continue reading from the stream 'serial' the value separator
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_map_value(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -1039,7 +1039,7 @@ m_ser1al_str_json_read_map_value(m_serial_local_t local, m_serial_read_t serial)
    Return M_SERIAL_OK_CONTINUE if it succeeds and the map continue,
    M_SERIAL_OK_DONE if it succeeds and the map ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_map_next(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -1052,7 +1052,7 @@ m_ser1al_str_json_read_map_next(m_serial_local_t local, m_serial_read_t serial)
 /* Start reading a tuple from the stream 'serial'.
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_tuple_start(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -1068,7 +1068,7 @@ m_ser1al_str_json_read_tuple_start(m_serial_local_t local, m_serial_read_t seria
    Return M_SERIAL_OK_CONTINUE if it succeeds and the tuple continues,
    Return M_SERIAL_OK_DONE if it succeeds and the tuple ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, const char *const field_name [], const int max, int *id)
 {
   (void) local; // argument not used
@@ -1109,7 +1109,7 @@ m_ser1al_str_json_read_tuple_id(m_serial_local_t local, m_serial_read_t serial, 
    Return M_SERIAL_OK_CONTINUE if it succeeds and the variant continues,
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends(variant is empty),
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_variant_start(m_serial_local_t local, m_serial_read_t serial, const char *const field_name[], const int max, int*id)
 {
   (void) local; // argument not used
@@ -1146,7 +1146,7 @@ m_ser1al_str_json_read_variant_start(m_serial_local_t local, m_serial_read_t ser
 /* End reading a variant from the stream 'serial'.
    Return M_SERIAL_OK_DONE if it succeeds and the variant ends,
    M_SERIAL_FAIL otherwise */
-static inline  m_serial_return_code_t
+M_INLINE  m_serial_return_code_t
 m_ser1al_str_json_read_variant_end(m_serial_local_t local, m_serial_read_t serial)
 {
   (void) local; // argument not used
@@ -1173,14 +1173,14 @@ static const m_serial_read_interface_t m_ser1al_str_json_read_interface = {
 };
 
 /* Initialize the JSON serial object for reading any object from JSON format in the given const string */
-static inline void m_serial_str_json_read_init(m_serial_read_t serial, const char str[])
+M_INLINE void m_serial_str_json_read_init(m_serial_read_t serial, const char str[])
 {
   serial->m_interface = &m_ser1al_str_json_read_interface;
   serial->data[0].cstr = str;
 }
 
 /* Clear the JSON serial object for reading from the FILE */
-static inline const char *m_serial_str_json_read_clear(m_serial_read_t serial)
+M_INLINE const char *m_serial_str_json_read_clear(m_serial_read_t serial)
 {
   // Nothing to clear. Return pointer to the last data parsed.
   return serial->data[0].cstr;

--- a/m-shared.h
+++ b/m-shared.h
@@ -136,10 +136,10 @@ M_BEGIN_PROTECTED_CODE
                                 IT_CREF(m_shar3d_integer_cref))
 
 /* Atomic like interface for basic integers */
-static inline void m_shar3d_integer_init_set(int *p, int val) { *p = val; }
-static inline int m_shar3d_integer_add(int *p, int val) { int r = *p;  *p += val; return r; }
-static inline int m_shar3d_integer_sub(int *p, int val) { int r = *p;  *p -= val; return r; }
-static inline int m_shar3d_integer_cref(int *p) { return *p; }
+M_INLINE void m_shar3d_integer_init_set(int *p, int val) { *p = val; }
+M_INLINE int m_shar3d_integer_add(int *p, int val) { int r = *p;  *p += val; return r; }
+M_INLINE int m_shar3d_integer_sub(int *p, int val) { int r = *p;  *p -= val; return r; }
+M_INLINE int m_shar3d_integer_cref(int *p) { return *p; }
 
 
 /********************************** INTERNAL *********************************/
@@ -189,13 +189,13 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
 /* Define the core functions */
 #define M_SHAR3D_PTR_DEF_CORE(name, type, oplist, cpt_oplist, shared_t)       \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(shared_t shared)                                           \
   {                                                                           \
     *shared = NULL;                                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init2)(shared_t shared, type *data)                              \
   {                                                                           \
     M_ASSERT (shared != NULL);                                                \
@@ -218,7 +218,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT, oplist)(                                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_new)(shared_t shared)                                       \
   {                                                                           \
     /* NOTE: Alloc 1 struct with both structures. */                          \
@@ -239,14 +239,14 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
   }                                                                           \
   , /* No INIT */ )                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _NULL_p)(const shared_t shared)                                   \
   {                                                                           \
     M_SHAR3D_CONTRACT(shared, cpt_oplist);                                    \
     return *shared == NULL;                                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(shared_t dest,                                         \
                        const shared_t shared)                                 \
   {                                                                           \
@@ -260,7 +260,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_SHAR3D_CONTRACT(dest, cpt_oplist);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(shared_t dest)                                            \
   {                                                                           \
     M_SHAR3D_CONTRACT(dest, cpt_oplist);                                      \
@@ -281,14 +281,14 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_SHAR3D_CONTRACT(dest, cpt_oplist);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(shared_t dest)                                            \
   {                                                                           \
     /* NOTE: Clear will also set dest to NULL */                              \
     M_F(name, _clear)(dest);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(shared_t dest,                                              \
                   const shared_t shared)                                      \
   {                                                                           \
@@ -298,7 +298,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_F(name, _init_set)(dest, shared);                                       \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(shared_t dest,                                        \
                         shared_t shared)                                      \
   {                                                                           \
@@ -309,7 +309,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_SHAR3D_CONTRACT(dest, cpt_oplist);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(shared_t dest,                                             \
                    shared_t shared)                                           \
   {                                                                           \
@@ -320,7 +320,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_F(name, _init_move)(dest, shared);                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(shared_t p1,                                               \
                    shared_t p2)                                               \
   {                                                                           \
@@ -332,7 +332,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_SHAR3D_CONTRACT(p2, cpt_oplist);                                        \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const shared_t p1,                                      \
                       const shared_t p2)                                      \
   {                                                                           \
@@ -341,7 +341,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     return *p1 == *p2;                                                        \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(const shared_t shared)                                     \
   {                                                                           \
     M_SHAR3D_CONTRACT(shared, cpt_oplist);                                    \
@@ -351,7 +351,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     return M_CONST_CAST (type, data);                                         \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(shared_t shared)                                            \
   {                                                                           \
     M_SHAR3D_CONTRACT(shared, cpt_oplist);                                    \
@@ -410,7 +410,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
 
 /* Define the core functions */
 #define M_SHAR3D_RESOURCE_DEF_CORE(name, type, oplist, shared_t, it_t)        \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(shared_t s, size_t n)                                      \
   {                                                                           \
     M_ASSERT(s != NULL);                                                      \
@@ -428,7 +428,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     M_SHAR3D_RESOURCE_CONTRACT(s);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(shared_t s)                                               \
   {                                                                           \
     M_SHAR3D_RESOURCE_CONTRACT(s);                                            \
@@ -441,7 +441,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     m_genint_clear(s->core);                                                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it)(it_t it, shared_t s)                                         \
   {                                                                           \
     M_SHAR3D_RESOURCE_CONTRACT(s);                                            \
@@ -455,14 +455,14 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _end_p)(it_t it)                                                  \
   {                                                                           \
     M_ASSERT (it != NULL);                                                    \
     return it->idx == M_GENINT_ERROR;                                         \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _ref)(it_t it)                                                    \
   {                                                                           \
     M_ASSERT (it != NULL && it->ref != NULL && it->idx != M_GENINT_ERROR);    \
@@ -470,7 +470,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     return &it->ref->buffer[it->idx].x;                                       \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _cref)(it_t it)                                                   \
   {                                                                           \
     M_ASSERT (it != NULL && it->ref != NULL && it->idx != M_GENINT_ERROR);    \
@@ -478,7 +478,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     return M_CONST_CAST (type, &it->ref->buffer[it->idx].x);                  \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _end)(it_t it, shared_t s)                                        \
   {                                                                           \
     M_SHAR3D_RESOURCE_CONTRACT(s);                                            \
@@ -494,7 +494,7 @@ static inline int m_shar3d_integer_cref(int *p) { return *p; }
     }                                                                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _it_set)(it_t itd, it_t its)                                      \
   {                                                                           \
     M_ASSERT (itd != NULL && its != NULL);                                    \

--- a/m-snapshot.h
+++ b/m-snapshot.h
@@ -197,7 +197,7 @@ M_BEGIN_PROTECTED_CODE
 /* Define the core functions */
 #define M_SNAPSH0T_SPSC_DEF_CORE(name, type, oplist, snapshot_t)              \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(snapshot_t snap)                                           \
   {                                                                           \
     M_ASSERT(snap != NULL);                                                   \
@@ -208,7 +208,7 @@ M_BEGIN_PROTECTED_CODE
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(snapshot_t snap)                                          \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -218,7 +218,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* const is missing for org due to use of atomic_load of org */             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(snapshot_t snap, snapshot_t org)                       \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(org);                                            \
@@ -231,7 +231,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* const is missing for org due to use of atomic_load of org */             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(snapshot_t snap, snapshot_t org)                            \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -244,7 +244,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   M_IF_METHOD(INIT_MOVE, oplist)(                                             \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _init_move)(snapshot_t snap, snapshot_t org)                    \
     {                                                                         \
       M_SNAPSH0T_SPSC_CONTRACT(org);                                          \
@@ -259,7 +259,7 @@ M_BEGIN_PROTECTED_CODE
   ,) /* IF_METHOD (INIT_MOVE) */                                              \
                                                                               \
   M_IF_METHOD(MOVE, oplist)(                                                  \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _move)(snapshot_t snap,                                         \
                                         snapshot_t org)                       \
     {                                                                         \
@@ -275,7 +275,7 @@ M_BEGIN_PROTECTED_CODE
     }                                                                         \
   ,) /* IF_METHOD (MOVE) */                                                   \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _write)(snapshot_t snap)                                          \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -294,7 +294,7 @@ M_BEGIN_PROTECTED_CODE
     return &snap->data[M_SNAPSH0T_SPSC_W(nextFlags)].x;                       \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _read)(snapshot_t snap)                                           \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -319,7 +319,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* Non const due to use of atomic_load */                                   \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _updated_p)(snapshot_t snap)                                      \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -328,7 +328,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* Non const due to use of atomic_load */                                   \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _get_write_buffer)(snapshot_t snap)                               \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -337,7 +337,7 @@ M_BEGIN_PROTECTED_CODE
   }                                                                           \
                                                                               \
   /* Non const due to use of atomic_load */                                   \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _get_read_buffer)(snapshot_t snap)                                \
   {                                                                           \
     M_SNAPSH0T_SPSC_CONTRACT(snap);                                           \
@@ -382,7 +382,7 @@ typedef struct m_snapsh0t_mrsw_s {
   } while (0)
 
 /* Initialize m_snapsh0t_mrsw_ct for n readers (constructor) */
-static inline void
+M_INLINE void
 m_snapsh0t_mrsw_init(m_snapsh0t_mrsw_ct s, size_t n)
 {
   M_ASSERT (s != NULL);
@@ -415,7 +415,7 @@ m_snapsh0t_mrsw_init(m_snapsh0t_mrsw_ct s, size_t n)
 }
 
 /* Clear m_snapsh0t_mrsw_ct (destructor) */
-static inline void
+M_INLINE void
 m_snapsh0t_mrsw_clear(m_snapsh0t_mrsw_ct s)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -426,7 +426,7 @@ m_snapsh0t_mrsw_clear(m_snapsh0t_mrsw_ct s)
 }
 
 /* Return the current index that is written in the buffer */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_get_write_idx(m_snapsh0t_mrsw_ct s)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -434,7 +434,7 @@ m_snapsh0t_mrsw_get_write_idx(m_snapsh0t_mrsw_ct s)
 }
 
 /* Return the number of readers */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_size(m_snapsh0t_mrsw_ct s)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -443,7 +443,7 @@ m_snapsh0t_mrsw_size(m_snapsh0t_mrsw_ct s)
 
 /* Give the current index that is written to the readers,
    and return new available index for the writer thread */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_write_idx(m_snapsh0t_mrsw_ct s, unsigned int idx)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -485,7 +485,7 @@ m_snapsh0t_mrsw_write_idx(m_snapsh0t_mrsw_ct s, unsigned int idx)
 }
 
 /* Perform a swap of the current write buffer and return a new one */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_write(m_snapsh0t_mrsw_ct s)
 {
   s->currentWrite = m_snapsh0t_mrsw_write_idx(s, s->currentWrite);
@@ -494,7 +494,7 @@ m_snapsh0t_mrsw_write(m_snapsh0t_mrsw_ct s)
 }
 
 /* Start writing to the write buffer and return its index */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_write_start(m_snapsh0t_mrsw_ct s)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -509,7 +509,7 @@ m_snapsh0t_mrsw_write_start(m_snapsh0t_mrsw_ct s)
 }
 
 /* End writing to the given write buffer */
-static inline void
+M_INLINE void
 m_snapsh0t_mrsw_write_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -531,7 +531,7 @@ m_snapsh0t_mrsw_write_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
 }
 
 /* Start reading the latest written buffer and return the index to it */
-static inline unsigned int
+M_INLINE unsigned int
 m_snapsh0t_mrsw_read_start(m_snapsh0t_mrsw_ct s)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -574,7 +574,7 @@ m_snapsh0t_mrsw_read_start(m_snapsh0t_mrsw_ct s)
 }
 
 /* End the reading the given buffer */
-static inline void
+M_INLINE void
 m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
 {
   M_SNAPSH0T_SPMC_INT_CONTRACT(s);
@@ -639,7 +639,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
 /* Define the core functions */
 #define M_SNAPSH0T_SPMC_DEF_CORE(name, type, oplist, snapshot_t)              \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(snapshot_t snap, size_t nReader)                           \
   {                                                                           \
     M_ASSERT (snap != NULL);                                                  \
@@ -658,7 +658,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(snapshot_t snap)                                          \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
@@ -670,7 +670,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     m_snapsh0t_mrsw_clear(snap->core);                                        \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _write)(snapshot_t snap)                                          \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
@@ -678,7 +678,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     return &snap->data[idx].x;                                                \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _read_start)(snapshot_t snap)                                     \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
@@ -686,7 +686,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     return M_CONST_CAST(type, &snap->data[idx].x);                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_end)(snapshot_t snap, type const *old)                      \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
@@ -700,7 +700,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     m_snapsh0t_mrsw_read_end(snap->core, idx);                                \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _get_write_buffer)(snapshot_t snap)                               \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap);                                           \
@@ -746,7 +746,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
 /* Define the core functions */
 #define M_SNAPSH0T_MPMC_DEF_CORE(name, type, oplist, snapshot_t)              \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(snapshot_t snap, size_t nReader, size_t nWriter)           \
   {                                                                           \
     M_F(name, _mrsw_init)(snap->core, nReader + nWriter -1 );                 \
@@ -755,13 +755,13 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     m_snapsh0t_mrsw_write_end(snap->core->core, idx);                         \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(snapshot_t snap)                                          \
   {                                                                           \
     M_F(name, _mrsw_clear)(snap->core);                                       \
   }                                                                           \
                                                                               \
-  static inline type *                                                        \
+  M_INLINE type *                                                             \
   M_F(name, _write_start)(snapshot_t snap)                                    \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap->core);                                     \
@@ -769,7 +769,7 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     return &snap->core->data[idx].x;                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _write_end)(snapshot_t snap, type *old)                           \
   {                                                                           \
     M_SNAPSH0T_SPMC_CONTRACT(snap->core);                                     \
@@ -782,13 +782,13 @@ m_snapsh0t_mrsw_read_end(m_snapsh0t_mrsw_ct s, unsigned int idx)
     m_snapsh0t_mrsw_write_end(snap->core->core, idx);                         \
   }                                                                           \
                                                                               \
-  static inline type const *                                                  \
+  M_INLINE type const *                                                       \
   M_F(name, _read_start)(snapshot_t snap)                                     \
   {                                                                           \
     return M_F(name, _mrsw_read_start)(snap->core);                           \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _read_end)(snapshot_t snap, type const *old)                      \
   {                                                                           \
     M_F(name, _mrsw_read_end)(snap->core, old);                               \

--- a/m-string.h
+++ b/m-string.h
@@ -149,7 +149,7 @@ typedef struct m_string_it_s {
    the string structure remains trivially movable (which is an important
    property to have).
  */
-static inline bool
+M_INLINE bool
 m_str1ng_stack_p(const m_string_t s)
 {
   // Function can be called when contract is not fulfilled
@@ -157,7 +157,7 @@ m_str1ng_stack_p(const m_string_t s)
 }
 
 /* Internal method to set the size of the string (excluding final nul char) */
-static inline void
+M_INLINE void
 m_str1ng_set_size(m_string_t s, size_t size)
 {
   // Function can be called when contract is not fulfilled
@@ -171,7 +171,7 @@ m_str1ng_set_size(m_string_t s, size_t size)
 }
 
 /* Return the number of bytes of the string (excluding the final nul char) */
-static inline size_t
+M_INLINE size_t
 m_string_size(const m_string_t s)
 {
   // Function can be called when contract is not fulfilled
@@ -182,7 +182,7 @@ m_string_size(const m_string_t s)
 }
 
 /* Return the capacity of the string (including the final nul char) */
-static inline size_t
+M_INLINE size_t
 m_string_capacity(const m_string_t s)
 {
   // Function can be called when contract is not fulfilled
@@ -193,7 +193,7 @@ m_string_capacity(const m_string_t s)
 }
 
 /* Return a writable pointer to the array of char of the string */
-static inline char*
+M_INLINE char*
 m_str1ng_get_cstr(m_string_t v)
 {
   // Function can be called when contract is not fulfilled
@@ -203,7 +203,7 @@ m_str1ng_get_cstr(m_string_t v)
 }
 
 /* Return the string view a classic C string (const char *) */
-static inline const char*
+M_INLINE const char*
 m_string_get_cstr(const m_string_t v)
 {
   // Function cannot be called when contract is not fulfilled
@@ -215,7 +215,7 @@ m_string_get_cstr(const m_string_t v)
 
 /* Initialize the dynamic string (constructor) 
   and make it empty */
-static inline void
+M_INLINE void
 m_string_init(m_string_t s)
 {
   s->ptr = NULL;
@@ -225,7 +225,7 @@ m_string_init(m_string_t s)
 }
 
 /* Clear the Dynamic string (destructor) */
-static inline void
+M_INLINE void
 m_string_clear(m_string_t v)
 {
   M_STR1NG_CONTRACT(v);
@@ -239,14 +239,14 @@ m_string_clear(m_string_t v)
 }
 
 /* NOTE: Internaly used by M_STRING_DECL_INIT */
-static inline void m_str1ng_clear2(m_string_t *v) { m_string_clear(*v); }
-static inline m_string_ptr m_str1ng_init_ref(m_string_t v) { m_string_init(v); return v; }
+M_INLINE void m_str1ng_clear2(m_string_t *v) { m_string_clear(*v); }
+M_INLINE m_string_ptr m_str1ng_init_ref(m_string_t v) { m_string_init(v); return v; }
 
 /* Clear the Dynamic string (destructor)
   and return a heap pointer to the string.
   The ownership of the data is transfered back to the caller
   and the returned pointer has to be released by M_MEMORY_FREE. */
-static inline char *
+M_INLINE char *
 m_string_clear_get_cstr(m_string_t v)
 {
   M_STR1NG_CONTRACT(v);
@@ -271,7 +271,7 @@ m_string_clear_get_cstr(m_string_t v)
 }
 
 /* Make the string empty */
-static inline void
+M_INLINE void
 m_string_reset(m_string_t v)
 {
   M_STR1NG_CONTRACT (v);
@@ -281,7 +281,7 @@ m_string_reset(m_string_t v)
 }
 
 /* Return the selected byte-character of the string */
-static inline char
+M_INLINE char
 m_string_get_char(const m_string_t v, size_t index)
 {
   M_STR1NG_CONTRACT (v);
@@ -290,7 +290,7 @@ m_string_get_char(const m_string_t v, size_t index)
 }
 
 /* Set the selected byte-character of the string */
-static inline void
+M_INLINE void
 m_string_set_char(m_string_t v, size_t index, const char c)
 {
   M_STR1NG_CONTRACT (v);
@@ -299,7 +299,7 @@ m_string_set_char(m_string_t v, size_t index, const char c)
 }
 
 /* Test if the string is empty or not */
-static inline bool
+M_INLINE bool
 m_string_empty_p(const m_string_t v)
 {
   M_STR1NG_CONTRACT (v);
@@ -312,7 +312,7 @@ m_string_empty_p(const m_string_t v)
    It may move the string from stack based to heap based.
    Return a pointer to the writable string.
 */
-static inline char *
+M_INLINE char *
 m_str1ng_fit2size (m_string_t v, size_t size_alloc)
 {
   M_ASSERT_INDEX (0, size_alloc);
@@ -362,7 +362,7 @@ m_str1ng_fit2size (m_string_t v, size_t size_alloc)
 /* Modify the string capacity to be able to handle at least 'alloc'
    characters (including final nul char).
    It may reduce the allocation of the string if possible */
-static inline void
+M_INLINE void
 m_string_reserve(m_string_t v, size_t alloc)
 {
   M_STR1NG_CONTRACT (v);
@@ -407,7 +407,7 @@ m_string_reserve(m_string_t v, size_t alloc)
 }
 
 /* Set the string to the C string str */
-static inline void
+M_INLINE void
 m_string_set_cstr(m_string_t v, const char str[])
 {
   M_STR1NG_CONTRACT (v);
@@ -421,7 +421,7 @@ m_string_set_cstr(m_string_t v, const char str[])
 }
 
 /* Set the string to the n first characters of the C string str */
-static inline void
+M_INLINE void
 m_string_set_cstrn(m_string_t v, const char str[], size_t n)
 {
   M_STR1NG_CONTRACT (v);
@@ -437,7 +437,7 @@ m_string_set_cstrn(m_string_t v, const char str[], size_t n)
 }
 
 /* Set the string to the other one */
-static inline void
+M_INLINE void
 m_string_set (m_string_t v1, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v1);
@@ -452,7 +452,7 @@ m_string_set (m_string_t v1, const m_string_t v2)
 }
 
 /* Set the string to the n first characters of other one */
-static inline void
+M_INLINE void
 m_string_set_n(m_string_t v, const m_string_t ref, size_t offset, size_t length)
 {
   M_STR1NG_CONTRACT (v);
@@ -469,7 +469,7 @@ m_string_set_n(m_string_t v, const m_string_t ref, size_t offset, size_t length)
 
 /* Initialize the string and set it to the other one 
    (constructor) */
-static inline void
+M_INLINE void
 m_string_init_set(m_string_t v1, const m_string_t v2)
 {
   m_string_init(v1);
@@ -478,7 +478,7 @@ m_string_init_set(m_string_t v1, const m_string_t v2)
 
 /* Initialize the string and set it to the C string
    (constructor) */
-static inline void
+M_INLINE void
 m_string_init_set_cstr(m_string_t v1, const char str[])
 {
   m_string_init(v1);
@@ -488,7 +488,7 @@ m_string_init_set_cstr(m_string_t v1, const char str[])
 /* Initialize the string, set it to the other one,
    and destroy the other one.
    (constructor & destructor) */
-static inline void
+M_INLINE void
 m_string_init_move(m_string_t v1, m_string_t v2)
 {
   M_STR1NG_CONTRACT (v2);
@@ -499,7 +499,7 @@ m_string_init_move(m_string_t v1, m_string_t v2)
 }
 
 /* Swap the two strings v1 and v2 */
-static inline void
+M_INLINE void
 m_string_swap(m_string_t v1, m_string_t v2)
 {
   M_STR1NG_CONTRACT (v1);
@@ -516,7 +516,7 @@ m_string_swap(m_string_t v1, m_string_t v2)
 /* Set the string to the other one,
    and destroy the other one.
    (destructor) */
-static inline void
+M_INLINE void
 m_string_move(m_string_t v1, m_string_t v2)
 {
   m_string_clear(v1);
@@ -524,7 +524,7 @@ m_string_move(m_string_t v1, m_string_t v2)
 }
 
 /* Push the byte-character 'c' in the string 'v' */
-static inline void
+M_INLINE void
 m_string_push_back (m_string_t v, char c)
 {
   M_STR1NG_CONTRACT (v);
@@ -537,7 +537,7 @@ m_string_push_back (m_string_t v, char c)
 }
 
 /* Concatene the string with the C string */
-static inline void
+M_INLINE void
 m_string_cat_cstr(m_string_t v, const char str[])
 {
   M_STR1NG_CONTRACT (v);
@@ -551,7 +551,7 @@ m_string_cat_cstr(m_string_t v, const char str[])
 }
 
 /* Concatene the string with the other string */
-static inline void
+M_INLINE void
 m_string_cat(m_string_t v, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v2);
@@ -569,7 +569,7 @@ m_string_cat(m_string_t v, const m_string_t v2)
 
 /* Compare the string to the C string and
   return the sort order (negative if less, 0 if equal, positive if greater) */
-static inline int
+M_INLINE int
 m_string_cmp_cstr(const m_string_t v1, const char str[])
 {
   M_STR1NG_CONTRACT (v1);
@@ -579,7 +579,7 @@ m_string_cmp_cstr(const m_string_t v1, const char str[])
 
 /* Compare the string to the other string and
   return the sort order (negative if less, 0 if equal, positive if greater) */
-static inline int
+M_INLINE int
 m_string_cmp(const m_string_t v1, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v1);
@@ -588,7 +588,7 @@ m_string_cmp(const m_string_t v1, const m_string_t v2)
 }
 
 /* Test if the string is equal to the given C string */
-static inline bool
+M_INLINE bool
 m_string_equal_cstr_p(const m_string_t v1, const char str[])
 {
   M_STR1NG_CONTRACT(v1);
@@ -597,7 +597,7 @@ m_string_equal_cstr_p(const m_string_t v1, const char str[])
 }
 
 /* Test if the string is equal to the other string */
-static inline bool
+M_INLINE bool
 m_string_equal_p(const m_string_t v1, const m_string_t v2)
 {
   /* m_string_equal_p can be called with (at most) one string which is an OOR value.
@@ -616,7 +616,7 @@ m_string_equal_p(const m_string_t v1, const m_string_t v2)
    (case insentive according to the current locale)
    Note: doesn't work with UTF-8 strings.
 */
-static inline int
+M_INLINE int
 m_string_cmpi_cstr(const m_string_t v1, const char p2[])
 {
   M_STR1NG_CONTRACT (v1);
@@ -638,7 +638,7 @@ m_string_cmpi_cstr(const m_string_t v1, const char p2[])
    (case insentive according to the current locale)
    Note: doesn't work with UTF-8 strings.
 */
-static inline int
+M_INLINE int
 m_string_cmpi(const m_string_t v1, const m_string_t v2)
 {
   return m_string_cmpi_cstr(v1, m_string_get_cstr(v2));
@@ -649,7 +649,7 @@ m_string_cmpi(const m_string_t v1, const m_string_t v2)
    Return M_STRING_FAILURE if not found.
    By default, start is zero.
 */
-static inline size_t
+M_INLINE size_t
 m_string_search_char (const m_string_t v, char c, size_t start)
 {
   M_STR1NG_CONTRACT (v);
@@ -664,7 +664,7 @@ m_string_search_char (const m_string_t v, char c, size_t start)
    Return M_STRING_FAILURE if not found.
    By default, start is zero.
 */
-static inline size_t
+M_INLINE size_t
 m_string_search_rchar (const m_string_t v, char c, size_t start)
 {
   M_STR1NG_CONTRACT (v);
@@ -681,7 +681,7 @@ m_string_search_rchar (const m_string_t v, char c, size_t start)
 /* Search for the sub C string in the string from the position start
    Return M_STRING_FAILURE if not found.
    By default, start is zero. */
-static inline size_t
+M_INLINE size_t
 m_string_search_cstr(const m_string_t v, const char str[], size_t start)
 {
   M_STR1NG_CONTRACT (v);
@@ -695,7 +695,7 @@ m_string_search_cstr(const m_string_t v, const char str[], size_t start)
 /* Search for the sub other string v2 in the string v1 from the position start
    Return M_STRING_FAILURE if not found.
    By default, start is zero. */
-static inline size_t
+M_INLINE size_t
 m_string_search (const m_string_t v1, const m_string_t v2, size_t start)
 {
   M_STR1NG_CONTRACT (v2);
@@ -707,7 +707,7 @@ m_string_search (const m_string_t v1, const m_string_t v2, size_t start)
    in the string v1 from the position start
    Return M_STRING_FAILURE if not found.
    By default, start is zero. */
-static inline size_t
+M_INLINE size_t
 m_string_search_pbrk(const m_string_t v1, const char first_of[], size_t start)
 {
   M_STR1NG_CONTRACT (v1);
@@ -719,7 +719,7 @@ m_string_search_pbrk(const m_string_t v1, const char first_of[], size_t start)
 }
 
 /* Compare the string to the C string using strcoll */
-static inline int
+M_INLINE int
 m_string_strcoll_cstr(const m_string_t v, const char str[])
 {
   M_STR1NG_CONTRACT (v);
@@ -727,7 +727,7 @@ m_string_strcoll_cstr(const m_string_t v, const char str[])
 }
 
 /* Compare the string to the other string using strcoll */
-static inline int
+M_INLINE int
 m_string_strcoll (const m_string_t v1, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v2);
@@ -736,7 +736,7 @@ m_string_strcoll (const m_string_t v1, const m_string_t v2)
 
 /* Return the number of bytes of the segment of s
    that consists entirely of bytes in accept */
-static inline size_t
+M_INLINE size_t
 m_string_spn(const m_string_t v1, const char accept[])
 {
   M_STR1NG_CONTRACT (v1);
@@ -746,7 +746,7 @@ m_string_spn(const m_string_t v1, const char accept[])
 
 /* Return the number of bytes of the segment of s
    that consists entirely of bytes not in reject */
-static inline size_t
+M_INLINE size_t
 m_string_cspn(const m_string_t v1, const char reject[])
 {
   M_STR1NG_CONTRACT (v1);
@@ -755,7 +755,7 @@ m_string_cspn(const m_string_t v1, const char reject[])
 }
 
 /* Return the string left truncated to the first 'index' bytes */
-static inline void
+M_INLINE void
 m_string_left(m_string_t v, size_t index)
 {
   M_STR1NG_CONTRACT (v);
@@ -768,7 +768,7 @@ m_string_left(m_string_t v, size_t index)
 }
 
 /* Return the string right truncated from the 'index' position to the last position */
-static inline void
+M_INLINE void
 m_string_right(m_string_t v, size_t index)
 {
   M_STR1NG_CONTRACT (v);
@@ -789,7 +789,7 @@ m_string_right(m_string_t v, size_t index)
 /* Return the string from position index to size bytes.
    See also m_string_set_n
  */
-static inline void
+M_INLINE void
 m_string_mid (m_string_t v, size_t index, size_t size)
 {
   m_string_right(v, index);
@@ -800,7 +800,7 @@ m_string_mid (m_string_t v, size_t index, size_t size)
    into the C string str2 from start
    By default, start is zero.
 */
-static inline size_t
+M_INLINE size_t
 m_string_replace_cstr (m_string_t v, const char str1[], const char str2[], size_t start)
 {
   M_STR1NG_CONTRACT (v);
@@ -826,7 +826,7 @@ m_string_replace_cstr (m_string_t v, const char str1[], const char str2[], size_
    into the C string v2 from start
    By default, start is zero.
 */
-static inline size_t
+M_INLINE size_t
 m_string_replace (m_string_t v, const m_string_t v1, const m_string_t v2, size_t start)
 {
   M_STR1NG_CONTRACT (v);
@@ -837,7 +837,7 @@ m_string_replace (m_string_t v, const m_string_t v1, const m_string_t v2, size_t
 
 /* Replace in the string the sub-string at position 'pos' for 'len' bytes
    into the C string str2. */
-static inline void
+M_INLINE void
 m_string_replace_at (m_string_t v, size_t pos, size_t len, const char str2[])
 {
   M_STR1NG_CONTRACT (v);
@@ -862,7 +862,7 @@ m_string_replace_at (m_string_t v, size_t pos, size_t len, const char str2[])
 }
 
 /* Replace all occurences of str1 into str2 when strlen(str1) >= strlen(str2) */
-static inline void
+M_INLINE void
 m_str1ng_replace_all_cstr_1ge2 (m_string_t v, const char str1[], size_t str1len, const char str2[], size_t str2len)
 {
   M_STR1NG_CONTRACT (v);
@@ -909,7 +909,7 @@ m_str1ng_replace_all_cstr_1ge2 (m_string_t v, const char str1[], size_t str1len,
   src is the current character pointer (shall be initialized to the end of the string)
   pattern / pattern_size: the pattern to search.
   */
-static inline char *
+M_INLINE char *
 m_str1ng_strstr_r(char org[], char src[], const char pattern[], size_t pattern_size)
 {
   M_ASSERT(pattern_size >= 1);
@@ -926,7 +926,7 @@ m_str1ng_strstr_r(char org[], char src[], const char pattern[], size_t pattern_s
 }
 
 /* Replace all occurences of str1 into str2 when strlen(str1) < strlen(str2) */
-static inline void
+M_INLINE void
 m_str1ng_replace_all_cstr_1lo2 (m_string_t v, const char str1[], size_t str1len, const char str2[], size_t str2len)
 {
   M_STR1NG_CONTRACT (v);
@@ -968,7 +968,7 @@ m_str1ng_replace_all_cstr_1lo2 (m_string_t v, const char str1[], size_t str1len,
   M_STR1NG_CONTRACT (v);
 }
 
-static inline void
+M_INLINE void
 m_string_replace_all_cstr (m_string_t v, const char str1[], const char str2[])
 {
   size_t str1_l = strlen(str1);
@@ -981,7 +981,7 @@ m_string_replace_all_cstr (m_string_t v, const char str1[], const char str2[])
   }
 }
 
-static inline void
+M_INLINE void
 m_string_replace_all (m_string_t v, const m_string_t str1, const m_string_t str2)
 {
   size_t str1_l = m_string_size(str1);
@@ -1008,7 +1008,7 @@ m_string_replace_all (m_string_t v, const m_string_t str1, const m_string_t str2
 # error Unexpected UINT_MAX value (workaround: Define M_USE_FAST_STRING_CONV to 0).
 #endif
 
-static inline void
+M_INLINE void
 m_string_set_ui(m_string_t v, unsigned int n)
 {
   M_STR1NG_CONTRACT (v);
@@ -1030,7 +1030,7 @@ m_string_set_ui(m_string_t v, unsigned int n)
   M_STR1NG_CONTRACT (v);
 }
 
-static inline void
+M_INLINE void
 m_string_set_si(m_string_t v, int n)
 {
   M_STR1NG_CONTRACT (v);
@@ -1060,7 +1060,7 @@ m_string_set_si(m_string_t v, int n)
 #if M_USE_STDARG
 
 /* Format in the string the given printf format */
-static inline int
+M_INLINE int
 m_string_vprintf (m_string_t v, const char format[], va_list args)
 {
   M_STR1NG_CONTRACT (v);
@@ -1092,7 +1092,7 @@ m_string_vprintf (m_string_t v, const char format[], va_list args)
 }
 
 /* Format in the string the given printf format */
-static inline int
+M_INLINE int
 m_string_printf (m_string_t v, const char format[], ...)
 {
   M_STR1NG_CONTRACT (v);
@@ -1105,7 +1105,7 @@ m_string_printf (m_string_t v, const char format[], ...)
 }
 
 /* Append to the string the formatted string of the given printf format */
-static inline int
+M_INLINE int
 m_string_cat_vprintf (m_string_t v, const char format[], va_list args)
 {
   M_STR1NG_CONTRACT (v);
@@ -1138,7 +1138,7 @@ m_string_cat_vprintf (m_string_t v, const char format[], va_list args)
 }
 
 /* Append to the string the formatted string of the given printf format */
-static inline int
+M_INLINE int
 m_string_cat_printf (m_string_t v, const char format[], ...)
 {
   M_STR1NG_CONTRACT (v);
@@ -1151,12 +1151,12 @@ m_string_cat_printf (m_string_t v, const char format[], ...)
 }
 
 #if M_USE_FAST_STRING_CONV == 0
-static inline void
+M_INLINE void
 m_string_set_ui(m_string_t v, unsigned int n)
 {
   m_string_printf(v, "%u", n);
 }
-static inline void
+M_INLINE void
 m_string_set_si(m_string_t v, int n)
 {
   m_string_printf(v, "%d", n);
@@ -1168,7 +1168,7 @@ m_string_set_si(m_string_t v, int n)
 #if M_USE_STDIO
 
 /* Get a line/pureline/file from the FILE and store it in the string */
-static inline bool
+M_INLINE bool
 m_string_fgets(m_string_t v, FILE *f, m_string_fgets_t arg)
 {
   M_STR1NG_CONTRACT(v);
@@ -1210,7 +1210,7 @@ m_string_fgets(m_string_t v, FILE *f, m_string_fgets_t arg)
    Words are supposed to be separated each other by the given list of separator
    separator shall be a CONSTANT C array.
  */
-static inline bool
+M_INLINE bool
 m_string_fget_word (m_string_t v, const char separator[], FILE *f)
 {
   char buffer[128];
@@ -1269,7 +1269,7 @@ m_string_fget_word (m_string_t v, const char separator[], FILE *f)
 }
 
 /* Put the string in the given FILE without formatting */
-static inline bool
+M_INLINE bool
 m_string_fputs(FILE *f, const m_string_t v)
 {
   M_STR1NG_CONTRACT (v);
@@ -1280,7 +1280,7 @@ m_string_fputs(FILE *f, const m_string_t v)
 #endif // Have stdio
 
 /* Test if the string starts with the given C string */
-static inline bool
+M_INLINE bool
 m_string_start_with_str_p(const m_string_t v, const char str[])
 {
   M_STR1NG_CONTRACT (v);
@@ -1296,7 +1296,7 @@ m_string_start_with_str_p(const m_string_t v, const char str[])
 }
 
 /* Test if the string starts with the other string */
-static inline bool
+M_INLINE bool
 m_string_start_with_string_p(const m_string_t v, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v2);
@@ -1304,7 +1304,7 @@ m_string_start_with_string_p(const m_string_t v, const m_string_t v2)
 }
 
 /* Test if the string ends with the C string */
-static inline bool
+M_INLINE bool
 m_string_end_with_str_p(const m_string_t v, const char str[])
 {
   M_STR1NG_CONTRACT (v);
@@ -1318,7 +1318,7 @@ m_string_end_with_str_p(const m_string_t v, const char str[])
 }
 
 /* Test if the string ends with the other string */
-static inline bool
+M_INLINE bool
 m_string_end_with_string_p(const m_string_t v, const m_string_t v2)
 {
   M_STR1NG_CONTRACT (v2);
@@ -1326,7 +1326,7 @@ m_string_end_with_string_p(const m_string_t v, const m_string_t v2)
 }
 
 /* Compute a hash for the string */
-static inline size_t
+M_INLINE size_t
 m_string_hash(const m_string_t v)
 {
   M_STR1NG_CONTRACT (v);
@@ -1334,7 +1334,7 @@ m_string_hash(const m_string_t v)
 }
 
 // Return true if c is a character from charac
-static inline bool
+M_INLINE bool
 m_str1ng_strim_char(char c, const char charac[])
 {
   for(const char *s = charac; *s; s++) {
@@ -1346,7 +1346,7 @@ m_str1ng_strim_char(char c, const char charac[])
 
 /* Remove any characters from charac that are present 
    in the begining of the string and the end of the string. */
-static inline void
+M_INLINE void
 m_string_strim(m_string_t v, const char charac[])
 {
   M_STR1NG_CONTRACT (v);
@@ -1368,14 +1368,14 @@ m_string_strim(m_string_t v, const char charac[])
 }
 
 /* Test if the string is equal to the OOR value */
-static inline bool
+M_INLINE bool
 m_string_oor_equal_p(const m_string_t s, unsigned char n)
 {
   return (s->ptr == NULL) & (s->u.heap.alloc == ~(size_t)n);
 }
 
 /* Set the unitialized string to the OOR value */
-static inline void
+M_INLINE void
 m_string_oor_set(m_string_t s, unsigned char n)
 {
   s->ptr = NULL;
@@ -1390,7 +1390,7 @@ m_string_oor_set(m_string_t s, unsigned char n)
 
 /* Transform the string 'v2' into a formatted string
    and set it to (or append in) the string 'v'. */
-static inline void
+M_INLINE void
 m_string_get_str(m_string_t v, const m_string_t v2, bool append)
 {
   M_STR1NG_CONTRACT(v2);
@@ -1444,7 +1444,7 @@ m_string_get_str(m_string_t v, const m_string_t v2, bool append)
 
 /* Transform the string 'v2' into a formatted string
    and output it in the given FILE */
-static inline void
+M_INLINE void
 m_string_out_str(FILE *f, const m_string_t v)
 {
   M_STR1NG_CONTRACT(v);
@@ -1481,7 +1481,7 @@ m_string_out_str(FILE *f, const m_string_t v)
 /* Read the formatted string from the FILE
    and set the converted value in the string 'v'.
    Return true in case of success */
-static inline bool
+M_INLINE bool
 m_string_in_str(m_string_t v, FILE *f)
 {
   M_STR1NG_CONTRACT(v);
@@ -1532,7 +1532,7 @@ m_string_in_str(m_string_t v, FILE *f)
    Return true in case of success
    If endptr is not null, update the position of the parsing.
 */
-static inline bool
+M_INLINE bool
 m_string_parse_str(m_string_t v, const char str[], const char **endptr)
 {
   M_STR1NG_CONTRACT(v);
@@ -1584,7 +1584,7 @@ m_string_parse_str(m_string_t v, const char str[], const char **endptr)
    and output it in the given serializer
    See serialization for return code.
 */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_string_out_serial(m_serial_write_t serial, const m_string_t v)
 {
   M_ASSERT (serial != NULL && serial->m_interface != NULL);
@@ -1595,7 +1595,7 @@ m_string_out_serial(m_serial_write_t serial, const m_string_t v)
    and set the converted value in the string 'v'.
    See serialization for return code.
 */
-static inline m_serial_return_code_t
+M_INLINE m_serial_return_code_t
 m_string_in_serial(m_string_t v, m_serial_read_t serial)
 {
   M_ASSERT (serial != NULL && serial->m_interface != NULL);
@@ -1635,7 +1635,7 @@ m_string_in_serial(m_string_t v, m_serial_read_t serial)
    It updates the state and the decoded unicode code point.
    A decoded unicoded code point is valid only when the state is STARTING.
  */
-static inline void
+M_INLINE void
 m_str1ng_utf8_decode(char c, m_str1ng_utf8_state_e *state,
                     m_string_unicode_t *unicode)
 {
@@ -1649,7 +1649,7 @@ m_str1ng_utf8_decode(char c, m_str1ng_utf8_state_e *state,
 
 /* Check if the given array of characters is a valid UTF8 stream */
 /* NOTE: Non-canonical representation are not always rejected */
-static inline bool
+M_INLINE bool
 m_str1ng_utf8_valid_str_p(const char str[])
 {
   m_str1ng_utf8_state_e s = M_STR1NG_UTF8_STARTING;
@@ -1667,14 +1667,14 @@ m_str1ng_utf8_valid_str_p(const char str[])
 }
 
 /* Test if the given byte is the start of an UTF8 code point */
-static inline bool
+M_INLINE bool
 m_str1ng_utf8_start_p(unsigned char val)
 {
   return ((val & 0xC0u) != 0x80u);
 }
 
 /* Computer the number of unicode code points are encoded in the UTF8 stream */
-static inline size_t
+M_INLINE size_t
 m_str1ng_utf8_length(const char str[])
 {
   size_t size = 0;
@@ -1686,7 +1686,7 @@ m_str1ng_utf8_length(const char str[])
 }
 
 /* Encode an unicode code point into an UTF8 stream */
-static inline int
+M_INLINE int
 m_str1ng_utf8_encode(char buffer[5], m_string_unicode_t u)
 {
   if (M_LIKELY (u <= 0x7Fu)) {
@@ -1715,7 +1715,7 @@ m_str1ng_utf8_encode(char buffer[5], m_string_unicode_t u)
 }
 
 /* Start iteration over the UTF8 encoded unicode code point */
-static inline void
+M_INLINE void
 m_string_it(m_string_it_t it, const m_string_t str)
 {
   M_STR1NG_CONTRACT(str);
@@ -1729,7 +1729,7 @@ m_string_it(m_string_it_t it, const m_string_t str)
 /* Set the iterator to the end of string 
    The iterator references therefore nothing.
 */
-static inline void
+M_INLINE void
 m_string_it_end(m_string_it_t it, const m_string_t str)
 {
   M_STR1NG_CONTRACT(str);
@@ -1741,7 +1741,7 @@ m_string_it_end(m_string_it_t it, const m_string_t str)
 }
 
 /* Set the iterator to the same position than the other one */
-static inline void
+M_INLINE void
 m_string_it_set(m_string_it_t it, const m_string_it_t itsrc)
 {
   M_ASSERT(it != NULL && itsrc != NULL);
@@ -1755,7 +1755,7 @@ m_string_it_set(m_string_it_t it, const m_string_it_t itsrc)
 /* Set the iterator to the given position in the string.
    The given position shall reference a valide code point in the string.
  */
-static inline void
+M_INLINE void
 m_string_it_pos(m_string_it_t it, const m_string_t str, const size_t n)
 {
   M_ASSERT(it != NULL);
@@ -1773,7 +1773,7 @@ m_string_it_pos(m_string_it_t it, const m_string_t str, const size_t n)
 /* Return the current offset in the string referenced by the iterator.
    This references avalid code point.
  */
-static inline size_t
+M_INLINE size_t
 m_string_it_get_pos(m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1781,7 +1781,7 @@ m_string_it_get_pos(m_string_it_t it)
 }
 
 /* Test if the iterator has reached the end of the string. */
-static inline bool
+M_INLINE bool
 m_string_end_p (m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1789,7 +1789,7 @@ m_string_end_p (m_string_it_t it)
 }
 
 /* Test if the iterator is equal to the other one */
-static inline bool
+M_INLINE bool
 m_string_it_equal_p(const m_string_it_t it1, const m_string_it_t it2)
 {
   M_STR1NG_IT_CONTRACT(it1);
@@ -1798,7 +1798,7 @@ m_string_it_equal_p(const m_string_it_t it1, const m_string_it_t it2)
 }
 
 /* Advance the iterator to the next UTF8 unicode code point */
-static inline void
+M_INLINE void
 m_string_next (m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1815,7 +1815,7 @@ m_string_next (m_string_it_t it)
 }
 
 /* Move the iterator to the previous code point */
-static inline void
+M_INLINE void
 m_string_previous(m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1835,7 +1835,7 @@ m_string_previous(m_string_it_t it)
 }
 
 /* Return the unicode code point associated to the iterator */
-static inline m_string_unicode_t
+M_INLINE m_string_unicode_t
 m_string_get_cref (const m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1855,7 +1855,7 @@ m_string_get_cref (const m_string_it_t it)
 }
 
 /* Return the unicode code point associated to the iterator */
-static inline const m_string_unicode_t *
+M_INLINE const m_string_unicode_t *
 m_string_cref (m_string_it_t it)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1914,7 +1914,7 @@ m_string_it_set_ref(m_string_it_t it, m_string_t s, m_string_unicode_t new_u)
 }
 
 /* Push unicode code point into string, encoding it in UTF8 */
-static inline void
+M_INLINE void
 m_string_push_u (m_string_t str, m_string_unicode_t u)
 {
   M_STR1NG_CONTRACT(str);
@@ -1956,7 +1956,7 @@ m_string_pop_u(m_string_unicode_t *u, m_string_t str)
 }
 
 /* Compute the length in UTF8 code points in the string */
-static inline size_t
+M_INLINE size_t
 m_string_length_u(m_string_t str)
 {
   M_STR1NG_CONTRACT(str);
@@ -1964,7 +1964,7 @@ m_string_length_u(m_string_t str)
 }
 
 /* Check if a string is a valid UTF8 encoded stream */
-static inline bool
+M_INLINE bool
 m_string_utf8_p(m_string_t str)
 {
   M_STR1NG_CONTRACT(str);
@@ -1975,7 +1975,7 @@ m_string_utf8_p(m_string_t str)
 /* Define the split & the join functions 
    in case of usage with the algorithm module */
 #define M_STR1NG_SPLIT(name, oplist, type_oplist)                             \
-  static inline void M_F(name, _split)(M_GET_TYPE oplist cont,                \
+  M_INLINE void M_F(name, _split)(M_GET_TYPE oplist cont,                     \
                                    const m_string_t str, const char sep)      \
   {                                                                           \
     size_t begin = 0;                                                         \
@@ -2005,7 +2005,7 @@ m_string_utf8_p(m_string_t str)
     m_string_clear(tmp);                                                      \
   }                                                                           \
                                                                               \
-  static inline void M_F(name, _join)(m_string_t dst, M_GET_TYPE oplist cont, \
+  M_INLINE void M_F(name, _join)(m_string_t dst, M_GET_TYPE oplist cont,      \
                                       const m_string_t str)                   \
   {                                                                           \
     bool init_done = false;                                                   \
@@ -2303,7 +2303,7 @@ namespace m_lib {
   /* Internal types for oplist */                                             \
   typedef bounded_t M_F(name, _ct);                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init)(bounded_t s)                                               \
   {                                                                           \
     M_ASSERT(s != NULL);                                                      \
@@ -2313,7 +2313,7 @@ namespace m_lib {
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _clear)(bounded_t s)                                              \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2321,7 +2321,7 @@ namespace m_lib {
     s->s[max_size] = 0x1F;                                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _reset)(bounded_t s)                                              \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2329,14 +2329,14 @@ namespace m_lib {
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _size)(const bounded_t s)                                         \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
     return strlen(s->s);                                                      \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _capacity)(const bounded_t s)                                     \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2344,7 +2344,7 @@ namespace m_lib {
     return max_size+1;                                                        \
   }                                                                           \
                                                                               \
-  static inline char                                                          \
+  M_INLINE char                                                               \
   M_F(name, _get_char)(const bounded_t s, size_t index)                       \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2352,14 +2352,14 @@ namespace m_lib {
     return s->s[index];                                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _empty_p)(const bounded_t s)                                      \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
     return s->s[0] == 0;                                                      \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_cstr)(bounded_t s, const char str[])                         \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2368,7 +2368,7 @@ namespace m_lib {
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_cstrn)(bounded_t s, const char str[], size_t n)              \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2379,14 +2379,14 @@ namespace m_lib {
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
   }                                                                           \
                                                                               \
-  static inline const char *                                                  \
+  M_INLINE const char *                                                       \
   M_F(name, _get_cstr)(const bounded_t s)                                     \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
     return s->s;                                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set)(bounded_t s, const bounded_t str)                           \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2394,7 +2394,7 @@ namespace m_lib {
     M_F(name, _set_cstr)(s, str->s);                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _set_n)(bounded_t s, const bounded_t str,                         \
                     size_t offset, size_t length)                             \
   {                                                                           \
@@ -2404,21 +2404,21 @@ namespace m_lib {
     M_F(name, _set_cstrn)(s, str->s+offset, length);                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set)(bounded_t s, const bounded_t str)                      \
   {                                                                           \
     M_F(name,_init)(s);                                                       \
     M_F(name,_set)(s, str);                                                   \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_set_cstr)(bounded_t s, const char str[])                    \
   {                                                                           \
     M_F(name,_init)(s);                                                       \
     M_F(name,_set_cstr)(s, str);                                              \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _cat_cstr)(bounded_t s, const char str[])                         \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2427,14 +2427,14 @@ namespace m_lib {
     m_core_strncat(s->s, max_size+1, str, max_size-strlen(s->s));             \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _cat)(bounded_t s, const bounded_t  str)                          \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(str, max_size);                                 \
     M_F(name, _cat_cstr)(s, str->s);                                          \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _cmp_cstr)(const bounded_t s, const char str[])                   \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2442,7 +2442,7 @@ namespace m_lib {
     return strcmp(s->s, str);                                                 \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _cmp)(const bounded_t s, const bounded_t str)                     \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2450,7 +2450,7 @@ namespace m_lib {
     return strcmp(s->s, str->s);                                              \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_cstr_p)(const bounded_t s, const char str[])               \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2458,14 +2458,14 @@ namespace m_lib {
     return strcmp(s->s, str) == 0;                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _equal_p)(const bounded_t s, const bounded_t str)                 \
   {                                                                           \
     /* _equal_p may be called in context OOR. So contract cannot be verified */ \
     return (s->s[max_size] == str->s[max_size]) & (strcmp(s->s, str->s) == 0); \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _printf)(bounded_t s, const char format[], ...)                   \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2478,7 +2478,7 @@ namespace m_lib {
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline int                                                           \
+  M_INLINE int                                                                \
   M_F(name, _cat_printf)(bounded_t s, const char format[], ...)               \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2493,7 +2493,7 @@ namespace m_lib {
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _fgets)(bounded_t s, FILE *f, m_string_fgets_t arg)               \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2509,7 +2509,7 @@ namespace m_lib {
     return ret != NULL;                                                       \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _fputs)(FILE *f, const bounded_t s)                               \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2517,7 +2517,7 @@ namespace m_lib {
     return fputs(s->s, f) >= 0;                                               \
   }                                                                           \
                                                                               \
-  static inline size_t                                                        \
+  M_INLINE size_t                                                             \
   M_F(name, _hash)(const bounded_t s)                                         \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2525,7 +2525,7 @@ namespace m_lib {
     return m_core_cstr_hash(s->s);                                            \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _oor_equal_p)(const bounded_t s, unsigned char n)                 \
   {                                                                           \
     /* s may be invalid contract */                                           \
@@ -2534,7 +2534,7 @@ namespace m_lib {
     return s->s[max_size] == (char) (n+1);                                    \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _oor_set)(bounded_t s, unsigned char n)                           \
   {                                                                           \
     /* s may be invalid contract */                                           \
@@ -2543,7 +2543,7 @@ namespace m_lib {
     s->s[max_size] = (char) (n+1);                                            \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _get_str)(m_string_t v, const bounded_t s, bool append)           \
   {                                                                           \
     M_STR1NG_CONTRACT(v);                                                     \
@@ -2557,7 +2557,7 @@ namespace m_lib {
     m_string_get_str(v, v2, append);                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _out_str)(FILE *f, const bounded_t s)                             \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(s, max_size);                                   \
@@ -2571,7 +2571,7 @@ namespace m_lib {
     m_string_out_str(f, v2);                                                  \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _in_str)(bounded_t v, FILE *f)                                    \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(v, max_size);                                   \
@@ -2584,7 +2584,7 @@ namespace m_lib {
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_F(name, _parse_str)(bounded_t v, const char str[], const char **endptr)   \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(v, max_size);                                   \
@@ -2597,7 +2597,7 @@ namespace m_lib {
     return ret;                                                               \
   }                                                                           \
                                                                               \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t serial, const bounded_t v)          \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(v, max_size);                                   \
@@ -2605,7 +2605,7 @@ namespace m_lib {
     return serial->m_interface->write_string(serial, v->s, strlen(v->s) );    \
   }                                                                           \
                                                                               \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(bounded_t v, m_serial_read_t serial)                  \
   {                                                                           \
     M_BOUNDED_STR1NG_CONTRACT(v, max_size);                                   \

--- a/m-string.h
+++ b/m-string.h
@@ -1864,7 +1864,7 @@ m_string_cref (m_string_it_t it)
 }
 
 /* Update the value referenced by the iterator to the given value */
-static inline void
+M_INLINE void
 m_string_it_set_ref(m_string_it_t it, m_string_t s, m_string_unicode_t new_u)
 {
   M_STR1NG_IT_CONTRACT(it);
@@ -1924,7 +1924,7 @@ m_string_push_u (m_string_t str, m_string_unicode_t u)
 }
 
 /* Pop last unicode code point into string, encoding it in UTF8 */
-static inline  bool
+M_INLINE  bool
 m_string_pop_u(m_string_unicode_t *u, m_string_t str)
 {
   M_STR1NG_CONTRACT(str);

--- a/m-thread.h
+++ b/m-thread.h
@@ -58,7 +58,7 @@ typedef cnd_t                  m_cond_t[1];
 typedef thrd_t                 m_thread_t[1];
 
 /* Initialize the mutex (constructor) */
-static inline void m_mutex_init(m_mutex_t m)
+M_INLINE void m_mutex_init(m_mutex_t m)
 {
   int rc = mtx_init(m, mtx_plain);
   // Abort program in case of initialization failure
@@ -67,25 +67,25 @@ static inline void m_mutex_init(m_mutex_t m)
 }
 
 /* Clear the mutex (destructor) */
-static inline void m_mutex_clear(m_mutex_t m)
+M_INLINE void m_mutex_clear(m_mutex_t m)
 {
   mtx_destroy(m);
 }
 
 /* Lock the mutex */
-static inline void m_mutex_lock(m_mutex_t m)
+M_INLINE void m_mutex_lock(m_mutex_t m)
 {
   mtx_lock(m);
 }
 
 /* Unlock the mutex */
-static inline void m_mutex_unlock(m_mutex_t m)
+M_INLINE void m_mutex_unlock(m_mutex_t m)
 {
   mtx_unlock(m);
 }
 
 /* Initialize the condition variable (constructor) */
-static inline void m_cond_init(m_cond_t c)
+M_INLINE void m_cond_init(m_cond_t c)
 {
   int rc = cnd_init(c);
   // Abort program in case of initialization failure
@@ -94,31 +94,31 @@ static inline void m_cond_init(m_cond_t c)
 }
 
 /* Clear the condition variable (destructor) */
-static inline void m_cond_clear(m_cond_t c)
+M_INLINE void m_cond_clear(m_cond_t c)
 {
   cnd_destroy(c);
 }
 
 /* Signal the condition variable to at least one waiting thread */
-static inline void m_cond_signal(m_cond_t c)
+M_INLINE void m_cond_signal(m_cond_t c)
 {
   cnd_signal(c);
 }
 
 /* Signal the condition variable to all waiting threads */
-static inline void m_cond_broadcast(m_cond_t c)
+M_INLINE void m_cond_broadcast(m_cond_t c)
 {
   cnd_broadcast(c);
 }
 
 /* Wait for signaling the condition variable by another thread */
-static inline void m_cond_wait(m_cond_t c, m_mutex_t m)
+M_INLINE void m_cond_wait(m_cond_t c, m_mutex_t m)
 {
   cnd_wait(c, m);
 }
 
 /* Create the thread (constructor) and start it */
-static inline void m_thread_create(m_thread_t t, void (*func)(void*), void* arg)
+M_INLINE void m_thread_create(m_thread_t t, void (*func)(void*), void* arg)
 {
   int rc = thrd_create(t, (int(*)(void*))(void(*)(void))func, arg);
   // Abort program in case of initialization failure
@@ -126,7 +126,7 @@ static inline void m_thread_create(m_thread_t t, void (*func)(void*), void* arg)
 }
 
 /* Wait for the thread to terminate and destroy it (destructor) */
-static inline void m_thread_join(m_thread_t t)
+M_INLINE void m_thread_join(m_thread_t t)
 {
   int rc = thrd_join(*t, NULL);
   M_ASSERT (rc == thrd_success);
@@ -136,14 +136,14 @@ static inline void m_thread_join(m_thread_t t)
 
 /* The thread has nothing meaningfull to do.
    Inform the OS to let other threads be scheduled */
-static inline void m_thread_yield(void)
+M_INLINE void m_thread_yield(void)
 {
   thrd_yield();
 }
 
 /* Sleep the thread for at least usec microseconds.
    Return true if the sleep was successful */
-static inline bool m_thread_sleep(unsigned long long usec)
+M_INLINE bool m_thread_sleep(unsigned long long usec)
 {
   struct timespec tv;
   tv.tv_sec = (long) (usec / 1000000ULL);
@@ -159,7 +159,7 @@ typedef once_flag                     m_once_t[1];
 #define M_ONCE_INIT_VALUE            { ONCE_FLAG_INIT }
 
 // Call the function exactly once
-static inline void m_once_call(m_once_t o, void (*func)(void))
+M_INLINE void m_once_call(m_once_t o, void (*func)(void))
 {
   call_once(o,func);
 }
@@ -223,68 +223,68 @@ typedef CRITICAL_SECTION       m_mutex_t[1];
 typedef CONDITION_VARIABLE     m_cond_t[1];
 
 /* Initialize a mutex (Constructor)*/
-static inline void m_mutex_init(m_mutex_t m)
+M_INLINE void m_mutex_init(m_mutex_t m)
 {
   InitializeCriticalSection(m);
 }
 
 /* Clear a mutex (destructor) */
-static inline void m_mutex_clear(m_mutex_t m)
+M_INLINE void m_mutex_clear(m_mutex_t m)
 {
   DeleteCriticalSection(m);
 }
 
 /* Lock a mutex */
-static inline void m_mutex_lock(m_mutex_t m)
+M_INLINE void m_mutex_lock(m_mutex_t m)
 {
   EnterCriticalSection(m);
 }
 
 /* Unlock a mutex */
-static inline void m_mutex_unlock(m_mutex_t m)
+M_INLINE void m_mutex_unlock(m_mutex_t m)
 {
   LeaveCriticalSection(m);
 }
 
 /* Initialize a condition variable (constructor) */
-static inline void m_cond_init(m_cond_t c)
+M_INLINE void m_cond_init(m_cond_t c)
 {
   InitializeConditionVariable(c);
 }
 
 /* Clear a condition variable (destructor) */
-static inline void m_cond_clear(m_cond_t c)
+M_INLINE void m_cond_clear(m_cond_t c)
 {
   (void) c; // There is no destructor for this object.
 }
 
 /* Signal a condition variable to at least one waiting thread */
-static inline void m_cond_signal(m_cond_t c)
+M_INLINE void m_cond_signal(m_cond_t c)
 {
   WakeConditionVariable(c);
 }
 
 /* Signal a condition variable to all waiting threads */
-static inline void m_cond_broadcast(m_cond_t c)
+M_INLINE void m_cond_broadcast(m_cond_t c)
 {
   WakeAllConditionVariable(c);
 }
 
 /* Wait for a condition variable */
-static inline void m_cond_wait(m_cond_t c, m_mutex_t m)
+M_INLINE void m_cond_wait(m_cond_t c, m_mutex_t m)
 {
   SleepConditionVariableCS(c, m, INFINITE);
 }
 
 /* Create a thread (constructor) and start it */
-static inline void m_thread_create(m_thread_t t, void (*func)(void*), void *arg)
+M_INLINE void m_thread_create(m_thread_t t, void (*func)(void*), void *arg)
 {
   *t = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE) (uintptr_t) func, arg, 0, NULL);
   M_ASSERT_INIT (*t != NULL, "thread");
 }
 
 /* Wait for the thread to terminate and destroy it (destructor) */
-static inline void m_thread_join(m_thread_t t)
+M_INLINE void m_thread_join(m_thread_t t)
 {
   DWORD dwWaitResult = WaitForSingleObject(*t, INFINITE);
   (void) dwWaitResult;
@@ -294,14 +294,14 @@ static inline void m_thread_join(m_thread_t t)
 
 /* The thread has nothing meaningfull to do.
    Inform the OS to let other threads be scheduled */
-static inline void m_thread_yield(void)
+M_INLINE void m_thread_yield(void)
 {
   Sleep(0);
 }
 
 /* Sleep the thread for at least usec microseconds
    Return true if the sleep was successful */
-static inline bool m_thread_sleep(unsigned long long usec)
+M_INLINE bool m_thread_sleep(unsigned long long usec)
 {
   LARGE_INTEGER ft;
   M_ASSERT (usec <= LLONG_MAX);
@@ -317,7 +317,7 @@ static inline bool m_thread_sleep(unsigned long long usec)
 
 typedef INIT_ONCE                     m_once_t[1];
 #define M_ONCE_INIT_VALUE            { INIT_ONCE_STATIC_INIT }
-static inline BOOL CALLBACK m_once_callback( PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext)
+M_INLINE BOOL CALLBACK m_once_callback( PINIT_ONCE InitOnce, PVOID Parameter, PVOID *lpContext)
 {
     void (*func)(void);
     (void) InitOnce;
@@ -326,7 +326,7 @@ static inline BOOL CALLBACK m_once_callback( PINIT_ONCE InitOnce, PVOID Paramete
     (*func)();
     return TRUE;
 }
-static inline void m_once_call(m_once_t o, void (*func)(void))
+M_INLINE void m_once_call(m_once_t o, void (*func)(void))
 {
   InitOnceExecuteOnce(o, m_once_callback, (void*)(intptr_t)func, NULL);
 }
@@ -368,7 +368,7 @@ typedef pthread_cond_t         m_cond_t[1];
 typedef pthread_t              m_thread_t[1];
 
 /* Initialize the mutex (constructor) */
-static inline void m_mutex_init(m_mutex_t m)
+M_INLINE void m_mutex_init(m_mutex_t m)
 {
   int _rc = pthread_mutex_init(m, NULL);
   // Abort program in case of initialization failure
@@ -377,19 +377,19 @@ static inline void m_mutex_init(m_mutex_t m)
 }
 
 /* Clear the mutex (destructor) */
-static inline void m_mutex_clear(m_mutex_t m)
+M_INLINE void m_mutex_clear(m_mutex_t m)
 {
   pthread_mutex_destroy(m);
 }
 
 /* Lock the mutex */
-static inline void m_mutex_lock(m_mutex_t m)
+M_INLINE void m_mutex_lock(m_mutex_t m)
 {
   pthread_mutex_lock(m);
 }
 
 /* Unlock the mutex */
-static inline void m_mutex_unlock(m_mutex_t m)
+M_INLINE void m_mutex_unlock(m_mutex_t m)
 {
   pthread_mutex_unlock(m);
 }
@@ -398,13 +398,13 @@ static inline void m_mutex_unlock(m_mutex_t m)
 #define M_MUTEXI_INIT_VALUE    { PTHREAD_MUTEX_INITIALIZER }
 
 /* Internal function compatible with lazy lock */
-static inline void m_mutexi_lazy_lock(m_mutex_t m)
+M_INLINE void m_mutexi_lazy_lock(m_mutex_t m)
 {
   pthread_mutex_lock(m);
 }
 
 /* Initialize the condition variable (constructor) */
-static inline void m_cond_init(m_cond_t c)
+M_INLINE void m_cond_init(m_cond_t c)
 {
   int _rc = pthread_cond_init(c, NULL);
   // Abort program in case of initialization failure
@@ -413,38 +413,38 @@ static inline void m_cond_init(m_cond_t c)
 }
 
 /* Clear the condition variable (destructor) */
-static inline void m_cond_clear(m_cond_t c)
+M_INLINE void m_cond_clear(m_cond_t c)
 {
   pthread_cond_destroy(c);
 }
 
 /* Signal a condition variable to at least a waiting thread */
-static inline void m_cond_signal(m_cond_t c)
+M_INLINE void m_cond_signal(m_cond_t c)
 {
   pthread_cond_signal(c);
 }
 
 /* Signal a condition variable to all waiting threads */
-static inline void m_cond_broadcast(m_cond_t c)
+M_INLINE void m_cond_broadcast(m_cond_t c)
 {
   pthread_cond_broadcast(c);
 }
 
 /* Waiting for a condition variable */
-static inline void m_cond_wait(m_cond_t c, m_mutex_t m)
+M_INLINE void m_cond_wait(m_cond_t c, m_mutex_t m)
 {
   pthread_cond_wait(c, m);
 }
 
 /* Create a thread (constructor) and start it */
-static inline void m_thread_create(m_thread_t t, void (*func)(void*), void *arg)
+M_INLINE void m_thread_create(m_thread_t t, void (*func)(void*), void *arg)
 {
   int _rc = pthread_create(t, NULL, (void*(*)(void*))(void(*)(void))func, arg);
   M_ASSERT_INIT (_rc == 0, "thread");
 }
 
 /* Wait for the thread to terminate and destroy it (destructor) */
-static inline void m_thread_join(m_thread_t t)
+M_INLINE void m_thread_join(m_thread_t t)
 {
   int _rc = pthread_join(*t, NULL);
   (void)_rc; // Avoid warning about variable unused.
@@ -453,7 +453,7 @@ static inline void m_thread_join(m_thread_t t)
 
 /* The thread has nothing meaningfull to do.
    Inform the OS to let other threads be scheduled */
-static inline void m_thread_yield(void)
+M_INLINE void m_thread_yield(void)
 {
 #ifdef _POSIX_PRIORITY_SCHEDULING
   sched_yield();
@@ -462,7 +462,7 @@ static inline void m_thread_yield(void)
 
 /* Sleep for at least usec microseconds
    Return true if the sleep was successful */
-static inline bool m_thread_sleep(unsigned long long usec)
+M_INLINE bool m_thread_sleep(unsigned long long usec)
 {
   struct timeval tv;
   /* We don't want to use usleep or nanosleep so that
@@ -475,7 +475,7 @@ static inline bool m_thread_sleep(unsigned long long usec)
 
 typedef pthread_once_t                m_once_t[1];
 #define M_ONCE_INIT_VALUE            { PTHREAD_ONCE_INIT }
-static inline void m_once_call(m_once_t o, void (*func)(void))
+M_INLINE void m_once_call(m_once_t o, void (*func)(void))
 {
   pthread_once(o,func);
 }

--- a/m-tree.h
+++ b/m-tree.h
@@ -204,7 +204,7 @@ typedef int32_t m_tr33_index_t;
 /* Define the core & unique methods of a tree */
 #define M_TR33_DEF_P4_CORE(name, type, oplist, tree_t, it_t)                  \
     /* Initialize a generic tree (empty) */                                   \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _init)(tree_t tree) {                                           \
         tree->size = 0;                                                       \
         tree->capacity = 0;                                                   \
@@ -215,7 +215,7 @@ typedef int32_t m_tr33_index_t;
         M_TR33_CONTRACT(tree);                                                \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _reset)(tree_t tree) {                                          \
         M_TR33_CONTRACT(tree);                                                \
         if (tree->size > 0) {                                                 \
@@ -241,7 +241,7 @@ typedef int32_t m_tr33_index_t;
         M_TR33_CONTRACT(tree);                                                \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _clear)(tree_t tree) {                                          \
         M_F(name, _reset)(tree);                                              \
         struct M_F(name,_node_s)*ptr = tree->tab == NULL ? NULL : tree->tab-1;\
@@ -251,7 +251,7 @@ typedef int32_t m_tr33_index_t;
         tree->tab = NULL;                                                     \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _reserve)(tree_t tree, size_t alloc) {                          \
         M_TR33_CONTRACT(tree);                                                \
         /* Nothing to do if the request is lower than the current capacity. */ \
@@ -298,14 +298,14 @@ typedef int32_t m_tr33_index_t;
         M_TR33_CONTRACT(tree);                                                \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _lock)(tree_t tree, bool lock) {                                \
         M_TR33_CONTRACT(tree);                                                \
         tree->allow_realloc = lock ? INT32_MAX : 0;                           \
         M_TR33_CONTRACT(tree);                                                \
     }                                                                         \
                                                                               \
-    static inline m_tr33_index_t                                              \
+    M_INLINE m_tr33_index_t                                                   \
     M_C3(m_tr33_, name, _alloc_node)(tree_t tree) {                           \
         m_tr33_index_t ret = tree->free_index;                                \
         if (M_UNLIKELY(ret < 0)) {                                            \
@@ -350,7 +350,7 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_C3(m_tr33_, name, _free_node)(tree_t tree, m_tr33_index_t i) {          \
         tree->tab[i].parent = M_TR33_NO_NODE;                                 \
         tree->tab[i].left   = M_TR33_NO_NODE;                                 \
@@ -360,7 +360,7 @@ typedef int32_t m_tr33_index_t;
         tree->free_index = i;                                                 \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _set_root)(tree_t tree, type const data) {                      \
         M_TR33_CONTRACT(tree);                                                \
         M_F(name, _reset)(tree);                                              \
@@ -380,7 +380,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* The iterator references the first root node */                         \
     /* usually for pre-order walk */                                          \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _it)(tree_t tree) {                                             \
         M_TR33_CONTRACT(tree);                                                \
         it_t it;                                                              \
@@ -390,7 +390,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _it_end)(tree_t tree) {                                         \
         M_TR33_CONTRACT(tree);                                                \
         it_t it;                                                              \
@@ -400,53 +400,53 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _end_p)(it_t it) {                                              \
         M_TR33_IT_CONTRACT(it, false);                                        \
         return it.index < 0;                                                  \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _ref)(it_t it) {                                                \
         M_TR33_IT_CONTRACT(it, true);                                         \
         return &it.tree->tab[it.index].data;                                  \
     }                                                                         \
                                                                               \
-    static inline type const *                                                \
+    M_INLINE type const *                                                     \
     M_F(name, _cref)(it_t it) {                                               \
         M_TR33_IT_CONTRACT(it, true);                                         \
         return M_CONST_CAST(type, &it.tree->tab[it.index].data);              \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _up_ref)(it_t it) {                                             \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = it.tree->tab[it.index].parent;                     \
         return i < 0 ? NULL : &it.tree->tab[i].data;                          \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _down_ref)(it_t it) {                                           \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = it.tree->tab[it.index].child;                      \
         return i < 0 ? NULL : &it.tree->tab[i].data;                          \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _left_ref)(it_t it) {                                           \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = it.tree->tab[it.index].left;                       \
         return i < 0 ? NULL : &it.tree->tab[i].data;                          \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _right_ref)(it_t it) {                                          \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = it.tree->tab[it.index].right;                      \
         return i < 0 ? NULL : &it.tree->tab[i].data;                          \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_up_raw)(it_t it) {                                      \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = M_C3(m_tr33_, name, _alloc_node)(it.tree);         \
@@ -476,7 +476,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_up)(it_t pos, type const data) {                        \
         it_t it = M_F(name, _insert_up_raw)(pos);                             \
         M_CALL_INIT_SET(oplist, it.tree->tab[it.index].data, data);           \
@@ -484,7 +484,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _move_up)(it_t pos, type *data) {                               \
         it_t it = M_F(name, _insert_up_raw)(pos);                             \
         M_DO_INIT_MOVE(oplist, it.tree->tab[it.index].data, *data);           \
@@ -492,7 +492,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_down_raw)(it_t it) {                                    \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t i = M_C3(m_tr33_, name, _alloc_node)(it.tree);         \
@@ -513,7 +513,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_down)(it_t pos, type const data) {                      \
         it_t it = M_F(name, _insert_down_raw)(pos);                           \
         M_CALL_INIT_SET(oplist, it.tree->tab[it.index].data, data);           \
@@ -521,7 +521,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _move_down)(it_t pos, type *data) {                             \
         it_t it = M_F(name, _insert_down_raw)(pos);                           \
         M_DO_INIT_MOVE(oplist, it.tree->tab[it.index].data, *data);           \
@@ -529,7 +529,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_child_raw)(it_t it) {                                   \
         M_TR33_IT_CONTRACT(it, true);                                         \
         /* Insert a node as a child of another, making the current childreen  \
@@ -550,7 +550,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_child)(it_t pos, type const data) {                     \
         it_t it = M_F(name, _insert_child_raw)(pos);                          \
         M_CALL_INIT_SET(oplist, it.tree->tab[it.index].data, data);           \
@@ -558,7 +558,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _move_child)(it_t pos, type *data) {                            \
         it_t it = M_F(name, _insert_child_raw)(pos);                          \
         M_DO_INIT_MOVE(oplist, it.tree->tab[it.index].data, *data);           \
@@ -566,7 +566,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_left_raw)(it_t it) {                                    \
         M_TR33_IT_CONTRACT(it, true);                                         \
         M_ASSERT(it.index != it.tree->root_index);                            \
@@ -590,7 +590,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_left)(it_t pos, type const data) {                      \
         it_t it = M_F(name, _insert_left_raw)(pos);                           \
         M_CALL_INIT_SET(oplist, it.tree->tab[it.index].data, data);           \
@@ -598,7 +598,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _move_left)(it_t pos, type *data) {                             \
         it_t it = M_F(name, _insert_left_raw)(pos);                           \
         M_DO_INIT_MOVE(oplist, it.tree->tab[it.index].data, *data);           \
@@ -606,7 +606,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_right_raw)(it_t it) {                                   \
         M_TR33_IT_CONTRACT(it, true);                                         \
         M_ASSERT(it.index != it.tree->root_index);                            \
@@ -624,7 +624,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _insert_right)(it_t pos, type const data) {                     \
         it_t it = M_F(name, _insert_right_raw)(pos);                          \
         M_CALL_INIT_SET(oplist, it.tree->tab[it.index].data, data);           \
@@ -632,7 +632,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _move_right)(it_t pos, type *data) {                            \
         it_t it = M_F(name, _insert_right_raw)(pos);                          \
         M_DO_INIT_MOVE(oplist, it.tree->tab[it.index].data, *data);           \
@@ -640,7 +640,7 @@ typedef int32_t m_tr33_index_t;
         return it;                                                            \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _it_up)(it_t *it) {                                             \
         M_ASSERT(it != NULL);                                                 \
         M_TR33_IT_CONTRACT(*it, true);                                        \
@@ -653,7 +653,7 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _it_down)(it_t *it) {                                           \
         M_ASSERT(it != NULL);                                                 \
         M_TR33_IT_CONTRACT(*it, true);                                        \
@@ -666,7 +666,7 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _it_left)(it_t *it) {                                           \
         M_ASSERT(it != NULL);                                                 \
         M_TR33_IT_CONTRACT(*it, true);                                        \
@@ -679,7 +679,7 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _it_right)(it_t *it) {                                          \
         M_ASSERT(it != NULL);                                                 \
         M_TR33_IT_CONTRACT(*it, true);                                        \
@@ -692,26 +692,26 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _root_p)(const it_t it) {                                       \
         M_TR33_IT_CONTRACT(it, true);                                         \
         return it.tree->tab[it.index].parent == M_TR33_ROOT_NODE;             \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _node_p)(const it_t it) {                                       \
         M_TR33_IT_CONTRACT(it, true);                                         \
         return it.tree->tab[it.index].child != M_TR33_NO_NODE;                \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _leaf_p)(const it_t it) {                                       \
         M_TR33_IT_CONTRACT(it, true);                                         \
         return it.tree->tab[it.index].child == M_TR33_NO_NODE;                \
     }                                                                         \
                                                                               \
     /* Compute the degree of a node in linear time */                         \
-    static inline int32_t                                                     \
+    M_INLINE int32_t                                                          \
     M_F(name, _degree)(const it_t it) {                                       \
         M_TR33_IT_CONTRACT(it, true);                                         \
         int32_t ret = 0;                                                      \
@@ -724,7 +724,7 @@ typedef int32_t m_tr33_index_t;
     }                                                                         \
                                                                               \
     /* Compute the depth of a node in linear time */                          \
-    static inline int32_t                                                     \
+    M_INLINE int32_t                                                          \
     M_F(name, _depth)(it_t it) {                                              \
         M_TR33_IT_CONTRACT(it, true);                                         \
         int32_t ret = 0;                                                      \
@@ -736,13 +736,13 @@ typedef int32_t m_tr33_index_t;
         return ret;                                                           \
     }                                                                         \
                                                                               \
-    static inline struct M_F(name, _s) *                                      \
+    M_INLINE struct M_F(name, _s) *                                           \
     M_F(name, _tree)(it_t it) {                                               \
         M_TR33_IT_CONTRACT(it, false);                                        \
         return it.tree;                                                       \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _swap_at)(it_t it1, it_t it2, bool swapChild) {                 \
         M_ASSUME(it1.tree == it2.tree);                                       \
         M_TR33_IT_CONTRACT(it1, true);                                        \
@@ -823,7 +823,7 @@ typedef int32_t m_tr33_index_t;
         M_TR33_IT_CONTRACT(it2, true);                                        \
     }                                                                         \
                                                                               \
-    static inline type *                                                      \
+    M_INLINE type *                                                           \
     M_F(name, _unlink)(it_t it) {                                             \
         M_TR33_IT_CONTRACT(it, true);                                         \
         m_tr33_index_t parent, child, left, right, child_r;                   \
@@ -884,7 +884,7 @@ typedef int32_t m_tr33_index_t;
         return &it.tree->tab[it.index].data;                                  \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _remove)(it_t it) {                                             \
         M_TR33_IT_CONTRACT(it, false);                                        \
         if (M_UNLIKELY(it.index < 0)) { return false; }                       \
@@ -895,7 +895,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the parent then the children (uses with _it) */  \
     /* pre-order walk */                                                      \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _next)(it_t *it) {                                              \
         M_TR33_IT_CONTRACT(*it, true);                                        \
         /* First go down, if impossible go right */                           \
@@ -915,7 +915,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the children then the parent */                  \
     /* post-order walk */                                                     \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _it_post)(tree_t tree) {                                        \
         M_TR33_CONTRACT(tree);                                                \
         it_t it;                                                              \
@@ -929,7 +929,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the children then the parent (uses with _it_post) */ \
     /* post-order walk */                                                     \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _next_post)(it_t *it) {                                         \
         M_TR33_IT_CONTRACT(*it, true);                                        \
         /* First go right */                                                  \
@@ -947,7 +947,7 @@ typedef int32_t m_tr33_index_t;
         M_TR33_IT_CONTRACT(*it, false);                                       \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _it_equal_p)(it_t it1, it_t it2) {                              \
         M_TR33_IT_CONTRACT(it1, false);                                       \
         M_TR33_IT_CONTRACT(it2, false);                                       \
@@ -956,7 +956,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the parent, then the children */                 \
     /* post-order walk */                                                     \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _it_subpre)(it_t it) {                                          \
         /* Nothing to do as it is already on the parent! */                   \
         return it;                                                            \
@@ -964,7 +964,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan the nodes of it_ref, first the parent then the children */        \
     /* pre-order walk */                                                      \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _next_subpre)(it_t *it, it_t it_ref) {                          \
         M_TR33_IT_CONTRACT(*it, true);                                        \
         M_TR33_IT_CONTRACT(it_ref, true);                                     \
@@ -985,7 +985,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the children then the parent */                  \
     /* post-order walk */                                                     \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _it_subpost)(it_t it) {                                         \
         M_TR33_IT_CONTRACT(it, true);                                         \
         /* Evaluate child first, so go down to the lowest child */            \
@@ -996,7 +996,7 @@ typedef int32_t m_tr33_index_t;
                                                                               \
     /* Scan all nodes, first the children then the parent (uses with _it_subpost) */ \
     /* post-order walk */                                                     \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _next_subpost)(it_t *it, it_t ref) {                            \
         M_TR33_IT_CONTRACT(*it, true);                                        \
         M_TR33_IT_CONTRACT(ref, true);                                        \
@@ -1018,7 +1018,7 @@ typedef int32_t m_tr33_index_t;
         assert(b);                                                            \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _prune)(it_t it) {                                              \
         M_TR33_IT_CONTRACT(it, true);                                         \
         /* remove the node, including its childs */                           \
@@ -1033,7 +1033,7 @@ typedef int32_t m_tr33_index_t;
         }                                                                     \
     }                                                                         \
                                                                               \
-    static inline it_t                                                        \
+    M_INLINE it_t                                                             \
     M_F(name, _lca)(it_t it1, it_t it2) {                                     \
         M_TR33_IT_CONTRACT(it1, true);                                        \
         M_TR33_IT_CONTRACT(it2, true);                                        \
@@ -1062,7 +1062,7 @@ typedef int32_t m_tr33_index_t;
         return it1;                                                           \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _graft_child)(it_t it1, const it_t it2) {                       \
         M_ASSERT(it1.tree == it2.tree);                                       \
         M_TR33_IT_CONTRACT(it1, true);                                        \
@@ -1094,7 +1094,7 @@ typedef int32_t m_tr33_index_t;
     }                                                                         \
                                                                               \
     M_IF_METHOD(CMP,oplist)(                                                  \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _sort_child)(it_t it0) {                                        \
         M_TR33_IT_CONTRACT(it0, true);                                        \
         it_t it1 = it0;                                                       \
@@ -1122,7 +1122,7 @@ typedef int32_t m_tr33_index_t;
 
 /* Define the classic extended missing methods of a tree */
 #define M_TR33_DEF_P4_EXT(name, type, oplist, tree_t, it_t)                   \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _init_set)(tree_t tree, const tree_t ref) {                     \
         tree->size = ref->size;                                               \
         tree->capacity = ref->capacity;                                       \
@@ -1155,14 +1155,14 @@ typedef int32_t m_tr33_index_t;
         M_TR33_CONTRACT(tree);                                                \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _set)(tree_t tree, const tree_t ref) {                          \
         /* No optimum, but good enought for present time */                   \
         M_F(name, _clear)(tree);                                              \
         M_F(name, _init_set)(tree, ref);                                      \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _init_move)(tree_t tree, tree_t ref) {                          \
         tree->size = ref->size;                                               \
         tree->capacity = ref->capacity;                                       \
@@ -1175,13 +1175,13 @@ typedef int32_t m_tr33_index_t;
         ref->tab = NULL;                                                      \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _move)(tree_t tree, tree_t ref) {                               \
         M_F(name, _clear)(tree);                                              \
         M_F(name, _init_move)(tree, ref);                                     \
     }                                                                         \
                                                                               \
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _swap)(tree_t tree1, tree_t tree2) {                            \
         M_TR33_CONTRACT(tree1);                                               \
         M_TR33_CONTRACT(tree2);                                               \
@@ -1195,32 +1195,32 @@ typedef int32_t m_tr33_index_t;
         M_TR33_CONTRACT(tree2);                                               \
     }                                                                         \
                                                                               \
-    static inline size_t                                                      \
+    M_INLINE size_t                                                           \
     M_F(name, _size)(const tree_t tree) {                                     \
         M_TR33_CONTRACT(tree);                                                \
         return (size_t) tree->size;                                           \
     }                                                                         \
                                                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _empty_p)(const tree_t tree) {                                  \
         M_TR33_CONTRACT(tree);                                                \
         return tree->size == 0;                                               \
     }                                                                         \
                                                                               \
-    static inline size_t                                                      \
+    M_INLINE size_t                                                           \
     M_F(name, _capacity)(const tree_t tree) {                                 \
         M_TR33_CONTRACT(tree);                                                \
         return (size_t) tree->capacity;                                       \
     }                                                                         \
                                                                               \
     /* Service not really usefull as the affectation operator works with it */\
-    static inline void                                                        \
+    M_INLINE void                                                             \
     M_F(name, _it_set)(it_t *dst, it_t src ){                                 \
         *dst = src;                                                           \
     }                                                                         \
                                                                               \
     M_IF_METHOD(EQUAL, oplist)(                                               \
-    static inline bool                                                        \
+    M_INLINE bool                                                             \
     M_F(name, _equal_p)(/*const*/ tree_t t1, /*const*/ tree_t t2) {           \
         M_TR33_CONTRACT(t1);                                                  \
         M_TR33_CONTRACT(t2);                                                  \
@@ -1282,7 +1282,7 @@ typedef int32_t m_tr33_index_t;
     , /* No EQUAL */ )                                                        \
                                                                               \
     M_IF_METHOD(HASH, oplist)(                                                \
-    static inline size_t                                                      \
+    M_INLINE size_t                                                           \
     M_F(name, _hash)(/* const */ tree_t t1) {                                 \
         M_HASH_DECL(hash);                                                    \
         for(it_t it = M_F(name, _it)(t1);                                     \
@@ -1299,7 +1299,7 @@ typedef int32_t m_tr33_index_t;
 /* Define the IO methods of a tree */
 #define M_TR33_DEF_P4_IO(name, type, oplist, tree_t, it_t)                    \
 M_IF_METHOD(GET_STR, oplist)(                                                 \
-static inline void                                                            \
+M_INLINE void                                                                 \
 M_F(name, _get_str)(string_t str, /*const*/ tree_t tree, bool append) {       \
     (append ? m_string_cat_cstr : m_string_set_cstr) (str, "[");              \
     it_t it = M_F(name, _it)(tree);                                           \
@@ -1335,7 +1335,7 @@ M_F(name, _get_str)(string_t str, /*const*/ tree_t tree, bool append) {       \
 , /* No GET_STR */ )                                                          \
                                                                               \
 M_IF_METHOD(PARSE_STR, oplist)(                                               \
-static inline bool                                                            \
+M_INLINE bool                                                                 \
 M_F(name, _parse_str)(tree_t tree, const char str[], const char **endp) {     \
     M_TR33_CONTRACT(tree);                                                    \
     int cmd = 0;                                                              \
@@ -1400,7 +1400,7 @@ exit:                                                                         \
 , /* No PARSE_STR */ )                                                        \
                                                                               \
 M_IF_METHOD(OUT_STR, oplist)(                                                 \
-static inline void                                                            \
+M_INLINE void                                                                 \
 M_F(name, _out_str)(FILE *f, /*const*/ tree_t tree) {                         \
     fputc('[', f);                                                            \
     it_t it = M_F(name, _it)(tree);                                           \
@@ -1436,7 +1436,7 @@ M_F(name, _out_str)(FILE *f, /*const*/ tree_t tree) {                         \
 , /* No OUT_STR */ )                                                          \
                                                                               \
 M_IF_METHOD(IN_STR, oplist)(                                                  \
-static inline bool                                                            \
+M_INLINE bool                                                                 \
 M_F(name, _in_str)(tree_t tree, FILE *f) {                                    \
     M_TR33_CONTRACT(tree);                                                    \
     int cmd = 0;                                                              \
@@ -1511,7 +1511,7 @@ exit:                                                                         \
 
 /* Definition of the emplace_back functions */
 #define M_TR33_EMPLACE_ROOT_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline M_F(name, _it_ct)                                             \
+  M_INLINE M_F(name, _it_ct)                                                  \
     function_name(name_t tree                                                 \
                   M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )              \
     {                                                                         \
@@ -1533,7 +1533,7 @@ exit:                                                                         \
     }
 
 #define M_TR33_EMPLACE_UP_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline name_t                                                        \
+  M_INLINE name_t                                                             \
   function_name(name_t pos                                                    \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -1544,7 +1544,7 @@ exit:                                                                         \
   }
 
 #define M_TR33_EMPLACE_DOWN_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline name_t                                                        \
+  M_INLINE name_t                                                             \
   function_name(name_t pos                                                    \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -1555,7 +1555,7 @@ exit:                                                                         \
   }
 
 #define M_TR33_EMPLACE_CHILD_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline name_t                                                        \
+  M_INLINE name_t                                                             \
   function_name(name_t pos                                                    \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -1566,7 +1566,7 @@ exit:                                                                         \
   }
 
 #define M_TR33_EMPLACE_LEFT_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline name_t                                                        \
+  M_INLINE name_t                                                             \
   function_name(name_t pos                                                    \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \
@@ -1577,7 +1577,7 @@ exit:                                                                         \
   }
 
 #define M_TR33_EMPLACE_RIGHT_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline name_t                                                        \
+  M_INLINE name_t                                                             \
   function_name(name_t pos                                                    \
                 M_EMPLACE_LIST_TYPE_VAR(a, exp_emplace_type) )                \
   {                                                                           \

--- a/m-try.h
+++ b/m-try.h
@@ -306,7 +306,7 @@ typedef struct m_try_s {
         { __VA_ARGS__ } } )
 
 // Copy an exception to another.
-static inline void
+M_INLINE void
 m_exception_set(struct m_exception_s *out, const struct m_exception_s *in)
 {
   if (in != out) {
@@ -357,7 +357,7 @@ extern M_ATTR_NO_RETURN M_ATTR_COLD_FUNCTION void m_throw(const struct m_excepti
   }
 
 // Rethrow the error
-static inline void
+M_INLINE void
 m_rethrow(void)
 {
   M_ASSERT(m_global_error_list != NULL);
@@ -366,7 +366,7 @@ m_rethrow(void)
 
 // Catch the error code associated to the TRY block state
 // and provide a pointer to the exception (which is a global).
-static inline bool
+M_INLINE bool
 m_catch(m_try_t state, unsigned error_code, const struct m_exception_s **exception)
 {
   M_ASSERT(m_global_error_list == state);
@@ -383,7 +383,7 @@ m_catch(m_try_t state, unsigned error_code, const struct m_exception_s **excepti
 }
 
 // Initialize the state to a TRY state.
-static inline void
+M_INLINE void
 m_try_init(m_try_t state)
 {
   state->kind = M_STATE_TRY;
@@ -395,7 +395,7 @@ m_try_init(m_try_t state)
   M_LIKELY ((m_try_init(s), m_try_setjmp(((s)->data.buf)) != 1))
 
 // Disable the current TRY block.
-static inline void
+M_INLINE void
 m_try_clear(m_try_t state)
 {
   // Even if there is a CATCH block and an unstack of the exception
@@ -422,7 +422,7 @@ m_try_clear(m_try_t state)
 // However we register the position in the stack frame now so that in case of partial initialization
 // of the object (if the INIT operator of the object calls other INIT operators of composed fields),
 // since partial initialization will be unstacked naturally by the composing object.
-static inline bool
+M_INLINE bool
 m_try_cb_pre(m_try_t state)
 {
   state->kind = M_STATE_CLEAR_CB;
@@ -431,7 +431,7 @@ m_try_cb_pre(m_try_t state)
 }
 
 // We register the function to call of the initialized object.
-static inline bool
+M_INLINE bool
 m_try_cb_post(m_try_t state, void (M_TRY_FUNC_OPERATOR func)(void*), void *data)
 {
   state->data.clear.func = func;
@@ -442,14 +442,14 @@ m_try_cb_post(m_try_t state, void (M_TRY_FUNC_OPERATOR func)(void*), void *data)
 
 // The object will be cleared.
 // We can pop the stack frame of the errors.
-static inline void
+M_INLINE void
 m_try_cb_final(m_try_t state)
 {
   m_global_error_list = state->next;
 }
 
 // Pre initialization function. Save the stack frame for a longjmp
-static inline bool
+M_INLINE bool
 m_try_jump_pre(m_try_t state)
 {
   state->kind = M_STATE_CLEAR_JMPBUF;
@@ -458,7 +458,7 @@ m_try_jump_pre(m_try_t state)
 }
 
 // Post initialization function. Register the stack frame for a longjmp
-static inline void
+M_INLINE void
 m_try_jump_post(m_try_t state)
 {
   m_global_error_list = state;
@@ -469,7 +469,7 @@ m_try_jump_post(m_try_t state)
 
 // The object will be cleared.
 // We can pop the stack frame of the errors.
-static inline void
+M_INLINE void
 m_try_jump_final(m_try_t state)
 {
   m_global_error_list = state->next;

--- a/m-tuple.h
+++ b/m-tuple.h
@@ -242,7 +242,7 @@ namespace m_lib {
 
 /* Define the INIT method calling the INIT method for all params */
 #define M_TUPL3_DEFINE_INIT(name, ...)                                        \
-  static inline void M_F(name, _init)(M_F(name,_ct) my) {                     \
+  M_INLINE void M_F(name, _init)(M_F(name,_ct) my) {                          \
     M_MAP(M_TUPL3_DEFINE_INIT_FUNC , __VA_ARGS__)                             \
   }
 
@@ -251,7 +251,7 @@ namespace m_lib {
 
 /* Define the INIT_SET method calling the INIT_SET method for all params */
 #define M_TUPL3_DEFINE_INIT_SET(name, ...)                                    \
-  static inline void M_F(name, _init_set)(M_F(name,_ct) my , M_F(name,_ct) const org) { \
+  M_INLINE void M_F(name, _init_set)(M_F(name,_ct) my , M_F(name,_ct) const org) { \
     M_TUPL3_CONTRACT(org);                                                    \
     M_MAP(M_TUPL3_DEFINE_INIT_SET_FUNC , __VA_ARGS__)                         \
   }
@@ -260,7 +260,7 @@ namespace m_lib {
 
 /* Define the INIT_WITH method calling the INIT_SET method for all params. */
 #define M_TUPL3_DEFINE_INIT_SET2(name, ...)                                   \
-  static inline void M_F(name, _init_emplace)(M_F(name,_ct) my                \
+  M_INLINE void M_F(name, _init_emplace)(M_F(name,_ct) my                     \
                       M_MAP(M_TUPL3_DEFINE_INIT_SET2_PROTO, __VA_ARGS__)      \
                                            ) {                                \
     M_MAP(M_TUPL3_DEFINE_INIT_SET2_FUNC , __VA_ARGS__)                        \
@@ -275,7 +275,7 @@ namespace m_lib {
 
 /* Define the SET method calling the SET method for all params. */
 #define M_TUPL3_DEFINE_SET(name, ...)                                         \
-  static inline void M_F(name, _set)(M_F(name,_ct) my ,                       \
+  M_INLINE void M_F(name, _set)(M_F(name,_ct) my ,                            \
                                      M_F(name,_ct) const org) {               \
     M_TUPL3_CONTRACT(my);                                                     \
     M_TUPL3_CONTRACT(org);                                                    \
@@ -288,7 +288,7 @@ namespace m_lib {
 
 /* Define the SET_WITH method calling the SET method for all params. */
 #define M_TUPL3_DEFINE_SET2(name, ...)                                        \
-  static inline void M_F(name, _emplace)(M_F(name,_ct) my                     \
+  M_INLINE void M_F(name, _emplace)(M_F(name,_ct) my                          \
                       M_MAP(M_TUPL3_DEFINE_SET2_PROTO, __VA_ARGS__)           \
                                            ) {                                \
     M_TUPL3_CONTRACT(my);                                                     \
@@ -303,7 +303,7 @@ namespace m_lib {
 
 /* Define the CLEAR method calling the CLEAR method for all params. */
 #define M_TUPL3_DEFINE_CLEAR(name, ...)                                       \
-  static inline void M_F(name, _clear)(M_F(name,_ct) my) {                    \
+  M_INLINE void M_F(name, _clear)(M_F(name,_ct) my) {                         \
     M_TUPL3_CONTRACT(my);                                                     \
     M_MAP(M_TUPL3_DEFINE_CLEAR_FUNC , __VA_ARGS__)                            \
   }
@@ -317,18 +317,18 @@ namespace m_lib {
   M_MAP3(M_TUPL3_DEFINE_GETTER_FIELD_PROTO, name, __VA_ARGS__)
 
 #define M_TUPL3_DEFINE_GETTER_FIELD_PROTO(name, num, a)                       \
-  static inline M_TUPL3_GET_TYPE a * M_C3(name, _get_at_, M_TUPL3_GET_FIELD a) \
+  M_INLINE M_TUPL3_GET_TYPE a * M_C3(name, _get_at_, M_TUPL3_GET_FIELD a)     \
        (M_F(name,_ct) my) {                                                   \
     M_TUPL3_CONTRACT(my);                                                     \
     return &(my->M_TUPL3_GET_FIELD a);                                        \
   }                                                                           \
-  static inline M_TUPL3_GET_TYPE a const * M_C3(name, _cget_at_, M_TUPL3_GET_FIELD a) \
+  M_INLINE M_TUPL3_GET_TYPE a const * M_C3(name, _cget_at_, M_TUPL3_GET_FIELD a) \
     (M_F(name,_ct) const my) {                                                \
     M_TUPL3_CONTRACT(my);                                                     \
     return &(my->M_TUPL3_GET_FIELD a);                                        \
   }                                                                           \
   /* Same but uses numerical index for accessing the field (internal) */      \
-  static inline M_TUPL3_GET_TYPE a * M_C4(m_tupl3_, name, _get_at_, num)      \
+  M_INLINE M_TUPL3_GET_TYPE a * M_C4(m_tupl3_, name, _get_at_, num)           \
        (M_F(name,_ct) my) {                                                   \
     return &(my->M_TUPL3_GET_FIELD a);                                        \
   }                                                                           \
@@ -339,7 +339,7 @@ namespace m_lib {
   M_MAP2(M_TUPL3_DEFINE_SETTER_FIELD_PROTO, name, __VA_ARGS__)
 
 #define M_TUPL3_DEFINE_SETTER_FIELD_PROTO(name, a)                            \
-  static inline void M_C3(name, _set_, M_TUPL3_GET_FIELD a)                   \
+  M_INLINE void M_C3(name, _set_, M_TUPL3_GET_FIELD a)                        \
        (M_F(name,_ct) my, M_TUPL3_GET_TYPE a const M_TUPL3_GET_FIELD a) {     \
     M_TUPL3_CONTRACT(my);                                                     \
     M_TUPL3_CALL_SET(a, my ->M_TUPL3_GET_FIELD a, M_TUPL3_GET_FIELD a);       \
@@ -348,7 +348,7 @@ namespace m_lib {
 
 /* Define the CMP method by calling CMP methods for all params. */
 #define M_TUPL3_DEFINE_CMP(name, ...)                                         \
-  static inline int M_F(name, _cmp)(M_F(name,_ct) const e1 ,                  \
+  M_INLINE int M_F(name, _cmp)(M_F(name,_ct) const e1 ,                       \
                                     M_F(name,_ct) const e2) {                 \
     int i;                                                                    \
     M_TUPL3_CONTRACT(e1);                                                     \
@@ -369,7 +369,7 @@ namespace m_lib {
    FIXME: All oplists shall define the CMP operator or at least one?
 */
 #define M_TUPL3_DEFINE_CMP_ORDER(name, ...)                                   \
-  static inline int M_F(name, _cmp_order)(M_F(name,_ct) const e1 ,            \
+  M_INLINE int M_F(name, _cmp_order)(M_F(name,_ct) const e1 ,                 \
                                           M_F(name,_ct) const e2,             \
                                           const int order[]) {                \
     int i, r;                                                                 \
@@ -403,7 +403,7 @@ namespace m_lib {
   )
 
 #define M_TUPL3_DEFINE_CMP_FIELD_FUNC(name, field, func_cmp, oplist)          \
-  static inline int M_C3(name, _cmp_, field)(M_F(name,_ct) const e1 ,         \
+  M_INLINE int M_C3(name, _cmp_, field)(M_F(name,_ct) const e1 ,              \
                                              M_F(name,_ct) const e2) {        \
     M_TUPL3_CONTRACT(e1);                                                     \
     M_TUPL3_CONTRACT(e2);                                                     \
@@ -413,7 +413,7 @@ namespace m_lib {
 
 /* Define a EQUAL method by calling the EQUAL methods  for all params */
 #define M_TUPL3_DEFINE_EQUAL(name, ...)                                       \
-  static inline bool M_F(name, _equal_p)(M_F(name,_ct) const e1 ,             \
+  M_INLINE bool M_F(name, _equal_p)(M_F(name,_ct) const e1 ,                  \
                                          M_F(name,_ct) const e2) {            \
     bool b;                                                                   \
     M_TUPL3_CONTRACT(e1);                                                     \
@@ -431,7 +431,7 @@ namespace m_lib {
 
 /* Define a HASH method by calling the HASH methods  for all params */
 #define M_TUPL3_DEFINE_HASH(name, ...)                                        \
-  static inline size_t M_F(name, _hash)(M_F(name,_ct) const e1) {             \
+  M_INLINE size_t M_F(name, _hash)(M_F(name,_ct) const e1) {                  \
     M_TUPL3_CONTRACT(e1);                                                     \
     M_HASH_DECL(hash);                                                        \
     M_MAP(M_TUPL3_DEFINE_HASH_FUNC_P0, __VA_ARGS__)                           \
@@ -446,7 +446,7 @@ namespace m_lib {
 
 /* Define a GET_STR method by calling the GET_STR methods for all params */
 #define M_TUPL3_DEFINE_GET_STR(name, ...)                                     \
-  static inline void M_F(name, _get_str)(m_string_t str,                      \
+  M_INLINE void M_F(name, _get_str)(m_string_t str,                           \
                                          M_F(name,_ct) const el,              \
                                          bool append) {                       \
     bool comma = false;                                                       \
@@ -465,7 +465,7 @@ namespace m_lib {
 
 /* Define a OUT_STR method by calling the OUT_STR methods for all params */
 #define M_TUPL3_DEFINE_OUT_STR(name, ...)                                     \
-  static inline void M_F(name, _out_str)(FILE *f,                             \
+  M_INLINE void M_F(name, _out_str)(FILE *f,                                  \
                                          M_F(name,_ct) const el) {            \
     bool comma = false;                                                       \
     M_TUPL3_CONTRACT(el);                                                     \
@@ -483,7 +483,7 @@ namespace m_lib {
 
 /* Define a IN_STR method by calling the IN_STR methods for all params */
 #define M_TUPL3_DEFINE_IN_STR(name, ...)                                      \
-  static inline bool M_F(name, _in_str)(M_F(name,_ct) el, FILE *f) {          \
+  M_INLINE bool M_F(name, _in_str)(M_F(name,_ct) el, FILE *f) {               \
     bool comma = false;                                                       \
     M_TUPL3_CONTRACT(el);                                                     \
     M_ASSERT (f != NULL);                                                     \
@@ -506,7 +506,7 @@ namespace m_lib {
 
 /* Define a PARSE_STR method by calling the PARSE_STR methods for all params */
 #define M_TUPL3_DEFINE_PARSE_STR(name, ...)                                   \
-  static inline bool M_F(name, _parse_str)(M_F(name,_ct) el,                  \
+  M_INLINE bool M_F(name, _parse_str)(M_F(name,_ct) el,                       \
                                         const char str[],                     \
                                         const char **endptr) {                \
     M_TUPL3_CONTRACT(el);                                                     \
@@ -540,7 +540,7 @@ namespace m_lib {
 
 /* Define a OUT_SERIAL method by calling the OUT_SERIAL methods for all params */
 #define M_TUPL3_DEFINE_OUT_SERIAL(name, ...)                                  \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f,                                  \
                          M_F(name,_ct) const el) {                            \
     M_TUPL3_CONTRACT(el);                                                     \
@@ -567,7 +567,7 @@ namespace m_lib {
 
 /* Define a IN_SERIAL method by calling the IN_SERIAL methods for all params */
 #define M_TUPL3_DEFINE_IN_SERIAL(name, ...)                                   \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(M_F(name,_ct) el, m_serial_read_t f) {                \
     M_TUPL3_CONTRACT(el);                                                     \
     M_ASSERT (f != NULL && f->m_interface != NULL);                           \
@@ -600,7 +600,7 @@ namespace m_lib {
 
 /* Define a INIT_MOVE method by calling the INIT_MOVE methods for all params */
 #define M_TUPL3_DEFINE_INIT_MOVE(name, ...)                                   \
-  static inline void M_F(name, _init_move)(M_F(name,_ct) el, M_F(name,_ct) org) { \
+  M_INLINE void M_F(name, _init_move)(M_F(name,_ct) el, M_F(name,_ct) org) {  \
     M_TUPL3_CONTRACT(el);                                                     \
     M_MAP(M_TUPL3_DEFINE_INIT_MOVE_FUNC , __VA_ARGS__)                        \
   }
@@ -611,7 +611,7 @@ namespace m_lib {
 
 /* Define a MOVE method by calling the MOVE methods for all params */
 #define M_TUPL3_DEFINE_MOVE(name, ...)                                        \
- static inline void M_F(name, _move)(M_F(name,_ct) el, M_F(name,_ct) org) {   \
+ M_INLINE void M_F(name, _move)(M_F(name,_ct) el, M_F(name,_ct) org) {        \
     M_TUPL3_CONTRACT(el);                                                     \
     M_MAP(M_TUPL3_DEFINE_MOVE_FUNC , __VA_ARGS__)                             \
  }
@@ -622,7 +622,7 @@ namespace m_lib {
 
 /* Define a SWAP method by calling the SWAP methods for all params */
 #define M_TUPL3_DEFINE_SWAP(name, ...)                                        \
-  static inline void M_F(name, _swap)(M_F(name,_ct) el1, M_F(name,_ct) el2) { \
+  M_INLINE void M_F(name, _swap)(M_F(name,_ct) el1, M_F(name,_ct) el2) {      \
     M_TUPL3_CONTRACT(el1);                                                    \
     M_TUPL3_CONTRACT(el2);                                                    \
     M_MAP(M_TUPL3_DEFINE_SWAP_FUNC , __VA_ARGS__)                             \
@@ -634,7 +634,7 @@ namespace m_lib {
 
 /* Define a RESET method by calling the RESET methods for all params */
 #define M_TUPL3_DEFINE_RESET(name, ...)                                       \
-  static inline void M_F(name, _reset)(M_F(name,_ct) el1) {                   \
+  M_INLINE void M_F(name, _reset)(M_F(name,_ct) el1) {                        \
     M_TUPL3_CONTRACT(el1);                                                    \
     M_MAP(M_TUPL3_DEFINE_RESET_FUNC , __VA_ARGS__)                            \
   }                                                                           \

--- a/m-variant.h
+++ b/m-variant.h
@@ -219,14 +219,14 @@
 
 /* Define the INIT function. Init the variant to empty */
 #define M_VAR1ANT_DEFINE_INIT(name, ...)                                      \
-  static inline void M_F(name, _init)(M_F(name,_ct) my) {                     \
+  M_INLINE void M_F(name, _init)(M_F(name,_ct) my) {                          \
     my->type = M_F(name, _EMPTY);                                             \
   }
 
 
 /* Define the INIT_SET function. */
 #define M_VAR1ANT_DEFINE_INIT_SET(name, ...)                                  \
-  static inline void M_F(name, _init_set)(M_F(name,_ct) my ,                  \
+  M_INLINE void M_F(name, _init_set)(M_F(name,_ct) my ,                       \
                                           M_F(name,_ct) const org) {          \
     M_VAR1ANT_CONTRACT(name, org);                                            \
     my->type = org->type;                                                     \
@@ -246,7 +246,7 @@
 
 /* Define the SET function. */
 #define M_VAR1ANT_DEFINE_SET(name, ...)                                       \
-  static inline void M_F(name, _set)(M_F(name,_ct) my ,                       \
+  M_INLINE void M_F(name, _set)(M_F(name,_ct) my ,                            \
                                      M_F(name,_ct) const org) {               \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     M_VAR1ANT_CONTRACT(name, org);                                            \
@@ -273,7 +273,7 @@
 
 /* Define the CLEAR function. */
 #define M_VAR1ANT_DEFINE_CLEAR(name, ...)                                     \
-  static inline void M_F(name, _clear)(M_F(name,_ct) my) {                    \
+  M_INLINE void M_F(name, _clear)(M_F(name,_ct) my) {                         \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     switch (my->type) {                                                       \
       M_MAP2(M_VAR1ANT_DEFINE_CLEAR_FUNC, name,  __VA_ARGS__)                 \
@@ -291,11 +291,11 @@
 
 /* Define the TEST_P function. */
 #define M_VAR1ANT_DEFINE_TEST_P(name, ...)                                    \
-  static inline bool M_F(name, _empty_p)(M_F(name,_ct) const my) {            \
+  M_INLINE bool M_F(name, _empty_p)(M_F(name,_ct) const my) {                 \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     return my->type == M_F(name, _EMPTY);                                     \
   }                                                                           \
-  static inline enum M_F(name, _enum)                                         \
+  M_INLINE enum M_F(name, _enum)                                              \
   M_F(name, _type)(M_F(name,_ct) my) {                                        \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     return my->type;                                                          \
@@ -303,7 +303,7 @@
   M_MAP2(M_VAR1ANT_DEFINE_TEST_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_TEST_FUNC(name, a)                                   \
-  static inline bool                                                          \
+  M_INLINE bool                                                               \
   M_C4(name, _, M_VAR1ANT_GET_FIELD a, _p)(M_F(name,_ct) const my) {          \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     return my->type == M_C4(name, _, M_VAR1ANT_GET_FIELD a, _value);          \
@@ -315,7 +315,7 @@
   M_MAP2(M_VAR1ANT_DEFINE_INIT_FIELD_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_INIT_FIELD_FUNC(name, a)                             \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _init_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) my) {               \
     /* Reinit variable with the given value */                                \
     my->type = M_C4(name, _, M_VAR1ANT_GET_FIELD a, _value);                  \
@@ -328,7 +328,7 @@
   M_MAP2(M_VAR1ANT_DEFINE_INIT_SETTER_FIELD_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_INIT_SETTER_FIELD_FUNC(name, a)                      \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _init_set_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) my,             \
                                                M_VAR1ANT_GET_TYPE a const M_VAR1ANT_GET_FIELD a  ) { \
     my->type = M_C4(name, _, M_VAR1ANT_GET_FIELD a, _value);                  \
@@ -342,7 +342,7 @@
   M_MAP2(M_VAR1ANT_DEFINE_SETTER_FIELD_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_SETTER_FIELD_FUNC(name, a)                           \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _set_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) my,                  \
                                           M_VAR1ANT_GET_TYPE a const M_VAR1ANT_GET_FIELD a  ) { \
     M_VAR1ANT_CONTRACT(name, my);                                             \
@@ -364,7 +364,7 @@
   M_MAP2(M_VAR1ANT_DEFINE_GETTER_FIELD_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_GETTER_FIELD_FUNC(name, a)                           \
-  static inline M_VAR1ANT_GET_TYPE a *                                        \
+  M_INLINE M_VAR1ANT_GET_TYPE a *                                             \
   M_C3(name, _get_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) my) {                \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     if (my->type != M_C4(name, _, M_VAR1ANT_GET_FIELD a, _value) ) {          \
@@ -373,7 +373,7 @@
     return &my -> value . M_VAR1ANT_GET_FIELD a;                              \
   }                                                                           \
                                                                               \
-  static inline M_VAR1ANT_GET_TYPE a const *                                  \
+  M_INLINE M_VAR1ANT_GET_TYPE a const *                                       \
   M_C3(name, _cget_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) const my) {         \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     if (my->type != M_C4(name, _, M_VAR1ANT_GET_FIELD a, _value) ) {          \
@@ -397,7 +397,7 @@
   M_EMPLACE_QUEUE_DEF( (name, M_VAR1ANT_GET_FIELD a), M_F(name,_ct), M_C3(name, _emplace_, M_VAR1ANT_GET_FIELD a), M_VAR1ANT_GET_OPLIST a, M_VAR1ANT_DEFINE_EMPLACE_DEF)
 
 #define M_VAR1ANT_DEFINE_INIT_EMPLACE_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-static inline void                                                            \
+M_INLINE void                                                                 \
   function_name(name_t my                                                     \
                 M_EMPLACE_LIST_TYPE_VAR(ab, exp_emplace_type) )               \
   {                                                                           \
@@ -406,7 +406,7 @@ static inline void                                                            \
   }                                                                           \
 
 #define M_VAR1ANT_DEFINE_EMPLACE_DEF(name, name_t, function_name, oplist, init_func, exp_emplace_type) \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   function_name(name_t my                                                     \
                 M_EMPLACE_LIST_TYPE_VAR(ab, exp_emplace_type) )               \
   {                                                                           \
@@ -418,7 +418,7 @@ static inline void                                                            \
 
 /* Define the EQUAL_P function. */
 #define M_VAR1ANT_DEFINE_EQUAL(name, ...)                                     \
-  static inline bool M_F(name, _equal_p)(M_F(name,_ct) const e1 ,             \
+  M_INLINE bool M_F(name, _equal_p)(M_F(name,_ct) const e1 ,                  \
                                          M_F(name,_ct) const e2) {            \
     bool b;                                                                   \
     M_VAR1ANT_CONTRACT(name, e1);                                             \
@@ -442,7 +442,7 @@ static inline void                                                            \
 
 /* Define the HASH function. */
 #define M_VAR1ANT_DEFINE_HASH(name, ...)                                      \
-  static inline size_t M_F(name, _hash)(M_F(name,_ct) const e1) {             \
+  M_INLINE size_t M_F(name, _hash)(M_F(name,_ct) const e1) {                  \
     M_VAR1ANT_CONTRACT(name, e1);                                             \
     M_HASH_DECL(hash);                                                        \
     M_HASH_UP (hash, (unsigned int) (e1 -> type));                            \
@@ -462,7 +462,7 @@ static inline void                                                            \
 
 /* Define the INIT_MOVE function. */
 #define M_VAR1ANT_DEFINE_INIT_MOVE(name, ...)                                 \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _init_move)(M_F(name,_ct) el, M_F(name,_ct) org) {                \
     M_VAR1ANT_CONTRACT(name, org);                                            \
     el -> type = org -> type;                                                 \
@@ -486,7 +486,7 @@ static inline void                                                            \
    It can be optimized if both types are the same.
 */
 #define M_VAR1ANT_DEFINE_MOVE(name, ...)                                      \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _move)(M_F(name,_ct) el, M_F(name,_ct) org) {                     \
     M_VAR1ANT_CONTRACT(name, el);                                             \
     M_VAR1ANT_CONTRACT(name, org);                                            \
@@ -500,7 +500,7 @@ static inline void                                                            \
   M_MAP2(M_VAR1ANT_DEFINE_MOVER_FUNC, name, __VA_ARGS__)
 
 #define M_VAR1ANT_DEFINE_MOVER_FUNC(name, a)                                  \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(name, _move_, M_VAR1ANT_GET_FIELD a)(M_F(name,_ct) my,                 \
                                            M_VAR1ANT_GET_TYPE a  M_VAR1ANT_GET_FIELD a  ) { \
     M_VAR1ANT_CONTRACT(name, my);                                             \
@@ -514,7 +514,7 @@ static inline void                                                            \
 
 /* Define the SWAP function  */
 #define M_VAR1ANT_DEFINE_SWAP(name, ...)                                      \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_F(name, _swap)(M_F(name,_ct) el1, M_F(name,_ct) el2) {                    \
     M_VAR1ANT_CONTRACT(name, el1);                                            \
     M_VAR1ANT_CONTRACT(name, el2);                                            \
@@ -550,7 +550,7 @@ static inline void                                                            \
 
 /* Define the GET_STR function */
 #define M_VAR1ANT_DEFINE_GET_STR(name, ...)                                   \
-  static inline void M_F(name, _get_str)(m_string_t str,                      \
+  M_INLINE void M_F(name, _get_str)(m_string_t str,                           \
                                          M_F(name,_ct) const el,              \
                                          bool append) {                       \
     M_VAR1ANT_CONTRACT(name, el);                                             \
@@ -574,7 +574,7 @@ static inline void                                                            \
 
 /* Define the PARSE_STR function */
 #define M_VAR1ANT_DEFINE_PARSE_STR(name, ...)                                 \
-  static inline bool M_F(name, _parse_str)(M_F(name,_ct) el,                  \
+  M_INLINE bool M_F(name, _parse_str)(M_F(name,_ct) el,                       \
                                            const char str[],                  \
                                            const char **endp) {               \
     M_VAR1ANT_CONTRACT(name, el);                                             \
@@ -617,7 +617,7 @@ static inline void                                                            \
 
 /* Define the OUT_STR function */
 #define M_VAR1ANT_DEFINE_OUT_STR(name, ...)                                   \
-  static inline void M_F(name, _out_str)(FILE *f,                             \
+  M_INLINE void M_F(name, _out_str)(FILE *f,                                  \
                                          M_F(name,_ct) const el) {            \
     M_VAR1ANT_CONTRACT(name, el);                                             \
     M_ASSERT (f != NULL);                                                     \
@@ -638,7 +638,7 @@ static inline void                                                            \
 
 /* Define the IN_STR function */
 #define M_VAR1ANT_DEFINE_IN_STR(name, ...)                                    \
-  static inline bool M_F(name, _in_str)(M_F(name,_ct) el,                     \
+  M_INLINE bool M_F(name, _in_str)(M_F(name,_ct) el,                          \
                                         FILE *f) {                            \
     M_VAR1ANT_CONTRACT(name, el);                                             \
     M_ASSERT (f != NULL);                                                     \
@@ -680,7 +680,7 @@ static inline void                                                            \
 
 /* Define the OUT_SERIAL function */
 #define M_VAR1ANT_DEFINE_OUT_SERIAL(name, ...)                                \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _out_serial)(m_serial_write_t f,                                  \
                          M_F(name,_ct) const el) {                            \
     M_VAR1ANT_CONTRACT(name, el);                                             \
@@ -711,7 +711,7 @@ static inline void                                                            \
 
 /* Define the IN_SERIAL function */
 #define M_VAR1ANT_DEFINE_IN_SERIAL(name, ...)                                 \
-  static inline m_serial_return_code_t                                        \
+  M_INLINE m_serial_return_code_t                                             \
   M_F(name, _in_serial)(M_F(name,_ct) el,                                     \
                         m_serial_read_t f) {                                  \
     M_VAR1ANT_CONTRACT(name, el);                                             \
@@ -745,7 +745,7 @@ static inline void                                                            \
 
 /* Define the RESET function */
 #define M_VAR1ANT_DEFINE_RESET_FUNC(name, ...)                                \
-  static inline void M_F(name, _reset)(M_F(name,_ct) my)                      \
+  M_INLINE void M_F(name, _reset)(M_F(name,_ct) my)                           \
   {                                                                           \
     M_VAR1ANT_CONTRACT(name, my);                                             \
     M_F(name, _clear)(my);                                                    \

--- a/m-worker.h
+++ b/m-worker.h
@@ -232,7 +232,7 @@ typedef struct m_worker_sync_s {
 
 /* Define the callback */
 #define M_WORK3R_SPAWN_EXTEND_DEF_CALLBACK(name, ...)                         \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_work3r_, name, _clear)(struct M_C3(m_worker_, name, _s) *p)          \
   {                                                                           \
     M_MAP3(M_WORK3R_SPAWN_EXTEND_DEF_CALLBACK_CLEAR, data, __VA_ARGS__)       \
@@ -240,7 +240,7 @@ typedef struct m_worker_sync_s {
     M_MEMORY_DEL(p);                                                          \
   }                                                                           \
                                                                               \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C3(m_work3r_, name, _callback)(void *data)                                \
   {                                                                           \
     struct M_C3(m_worker_, name, _s) *p = (struct M_C3(m_worker_, name, _s) *) data; \
@@ -258,7 +258,7 @@ typedef struct m_worker_sync_s {
 
 /* Define the emplace like spawn method */
 #define M_WORK3R_SPAWN_EXTEND_DEF_EMPLACE(name, ...)                          \
-  static inline void                                                          \
+  M_INLINE void                                                               \
   M_C(m_worker_spawn_, name)(m_worker_sync_t block, M_C3(m_worker_, name, _callback_ct) callback, \
                              M_MAP3_C(M_WORK3R_SPAWN_EXTEND_DEF_EMPLACE_FIELD, data, __VA_ARGS__) \
                              )                                                \
@@ -299,7 +299,7 @@ typedef struct m_worker_sync_s {
 /* Return the number of CPU cores available in the system.
    Works for WINDOWS, MACOS, *BSD, LINUX.
  */
-static inline int
+M_INLINE int
 m_work3r_get_cpu_count(void)
 {
 #if defined(_WIN32)
@@ -332,7 +332,7 @@ m_work3r_get_cpu_count(void)
 #endif
 
 /* Execute the registered work order **synchronously** */
-static inline void
+M_INLINE void
 m_work3r_exec(m_work3r_order_ct *w)
 {
   M_ASSERT (w!= NULL && w->block != NULL);
@@ -356,7 +356,7 @@ m_work3r_exec(m_work3r_order_ct *w)
 
 
 /* The worker thread main loop*/
-static inline void
+M_INLINE void
 m_work3r_thread(void *arg)
 {
   // Get back the given argument
@@ -397,7 +397,7 @@ m_work3r_thread(void *arg)
    @resetFunc: function to reset the state of a worker between work orders (or NULL if none)
    @clearFunc: function to clear the state of a worker before terminaning (or NULL if none)
 */
-static inline void
+M_INLINE void
 m_worker_init(m_worker_t g, int numWorker, unsigned int extraQueue, void (*resetFunc)(void), void (*clearFunc)(void))
 {
   M_ASSERT (numWorker >= -1);
@@ -437,7 +437,7 @@ m_worker_init(m_worker_t g, int numWorker, unsigned int extraQueue, void (*reset
 #define m_worker_init(...) m_worker_init(M_DEFAULT_ARGS(5, (0, 0, NULL, NULL), __VA_ARGS__))
 
 /* Clear of the worker module (destructor) */
-static inline void
+M_INLINE void
 m_worker_clear(m_worker_t g)
 {
   M_ASSERT (m_work3r_queue_empty_p (g->queue_g));
@@ -462,7 +462,7 @@ m_worker_clear(m_worker_t g)
 
 /* Start a new collaboration between workers of pool 'g'
    by defining the synchronization point 'block' */
-static inline void
+M_INLINE void
 m_worker_start(m_worker_sync_t block, m_worker_t g)
 {
   atomic_init (&block->num_spawn, 0);
@@ -475,7 +475,7 @@ m_worker_start(m_worker_sync_t block, m_worker_t g)
    The synchronization point is defined a 'block'
    The work order if composed of the function 'func' and its 'data'
 */
-static inline void
+M_INLINE void
 m_worker_spawn(m_worker_sync_t block, void (*func)(void *data), void *data)
 {
   const m_work3r_order_ct w = {  block, data, func M_WORK3R_EXTRA_ORDER };
@@ -493,7 +493,7 @@ m_worker_spawn(m_worker_sync_t block, void (*func)(void *data), void *data)
 #if M_USE_WORKER_CLANG_BLOCK
 /* Spawn or not the given work order to workers,
    or do it ourself if no worker is available */
-static inline void
+M_INLINE void
 m_work3r_spawn_block(m_worker_sync_t block, void (^func)(void *data), void *data)
 {
   const m_work3r_order_ct w = {  block, data, NULL, func };
@@ -512,7 +512,7 @@ m_work3r_spawn_block(m_worker_sync_t block, void (^func)(void *data), void *data
 #if M_USE_WORKER_CPP_FUNCTION
 /* Spawn or not the given work order to workers,
    or do it ourself if no worker is available */
-static inline void
+M_INLINE void
 m_work3r_spawn_function(m_worker_sync_t block, std::function<void(void *data)> func, void *data)
 {
   const m_work3r_order_ct w = {  block, data, NULL, func };
@@ -529,7 +529,7 @@ m_work3r_spawn_function(m_worker_sync_t block, std::function<void(void *data)> f
 #endif
 
 /* Test if all work orders of the given synchronization point are finished */
-static inline bool
+M_INLINE bool
 m_worker_sync_p(m_worker_sync_t block)
 {
   /* If the number of spawns is greated than the number
@@ -539,7 +539,7 @@ m_worker_sync_p(m_worker_sync_t block)
 }
 
 /* Wait for all work orders of the given synchronization point to be finished */
-static inline void
+M_INLINE void
 m_worker_sync(m_worker_sync_t block)
 {
   M_WORK3R_DEBUG ("Waiting for thread terminasion.\n");
@@ -554,7 +554,7 @@ m_worker_sync(m_worker_sync_t block)
 }
 
 /* Flush any work order in the queue ourself if some remains.*/
-static inline void
+M_INLINE void
 m_worker_flush(m_worker_t g)
 {
   m_work3r_order_ct w;
@@ -566,7 +566,7 @@ m_worker_flush(m_worker_t g)
 
 
 /* Return the number of workers */
-static inline size_t
+M_INLINE size_t
 m_worker_count(m_worker_t g)
 {
   return g->numWorker_g + 1;


### PR DESCRIPTION
Use of compiler extension for that, only compatible for GCC /CLANG.
This provides easy and total customization (for example non template functions like strings can also avoid code duplication). 