### PR TITLE
Make m_typeof defined only if we are sure it is working

### DIFF
--- a/example/ex11-generic01.c
+++ b/example/ex11-generic01.c
@@ -1,4 +1,5 @@
-#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L) || defined(__GNUC__)
+#include "m-core.h"
+#if defined(m_typeof)
 
 #include "m-list.h"
 #include "m-generic.h"
@@ -47,7 +48,7 @@ int main(void)
 #include <stdio.h>
 int main(void)
 {
-    fprintf(stderr, "Error: C23 or GCC is required to compile this test\n");
+    fprintf(stderr, "Error: C23 or supported compiler is required to compile this test\n");
     return 1;
 }
 

--- a/example/ex11-generic02.c
+++ b/example/ex11-generic02.c
@@ -1,4 +1,5 @@
-#if HAVE_GMP && ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L) || defined(__GNUC__))
+#include "m-core.h"
+#if HAVE_GMP && defined(m_typeof)
 
 #include <stdio.h>
 #include <gmp.h>
@@ -120,7 +121,7 @@ int main(void) {
 #include <stdio.h>
 int main(void)
 {
-    fprintf(stderr, "Error: GMP and C23 or GCC is required to compile this test\n");
+    fprintf(stderr, "Error: GMP and C23 or supported compiler is required to compile this test\n");
     return 1;
 }
 #endif

--- a/example/ex11-generic03.c
+++ b/example/ex11-generic03.c
@@ -1,4 +1,5 @@
-#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L) || defined(__GNUC__)
+#include "m-core.h"
+#if defined(m_typeof)
 
 #include "m-array.h"
 #include "m-deque.h"
@@ -69,7 +70,7 @@ int main(void)
 #include <stdio.h>
 int main(void)
 {
-    fprintf(stderr, "Error: C23 or GCC is required to compile this test\n");
+    fprintf(stderr, "Error: C23 or supported compiler is required to compile this test\n");
     return 1;
 }
 #endif

--- a/m-core.h
+++ b/m-core.h
@@ -4287,7 +4287,7 @@ M_INLINE size_t m_core_cstr_hash(const char str[])
 #define M_CHECK_SAME(a, b) (void)0
 #elif defined(__GNUC__) && !defined(__cplusplus)
 #define M_CHECK_SAME(a, b)                                                    \
-  M_STATIC_ASSERT(__builtin_types_compatible_p(m_typeof(a), m_typeof(b)),     \
+  M_STATIC_ASSERT(__builtin_types_compatible_p(m_typeof(((void)0,a)), m_typeof(((void)0,b))), \
                   M_LIB_NOT_SAME_TYPE,                                        \
                   "The variable " M_AS_STR(a) " and " M_AS_STR(b)             \
                   " are not of same type.")

--- a/m-core.h
+++ b/m-core.h
@@ -157,9 +157,9 @@
    Otherwise we use some extensions of the compilers. */
 #ifdef _MSC_VER
 #define m_typeof(x) decltype(x)
-#elif defined(__GNUC__)   
+#elif defined(__GNUC__) || defined(__clang__) || defined(__TINYC__) || defined(__slimcc__)
 #define m_typeof(x) __typeof__(x)
-#else
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L
 #define m_typeof(x) typeof(x)
 #endif
 
@@ -4291,7 +4291,7 @@ M_INLINE size_t m_core_cstr_hash(const char str[])
                   M_LIB_NOT_SAME_TYPE,                                        \
                   "The variable " M_AS_STR(a) " and " M_AS_STR(b)             \
                   " are not of same type.")
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202000L
+#elif defined(m_typeof)
 #define M_CHECK_SAME(a, b)                                                    \
   M_STATIC_ASSERT(_Generic(&a, m_typeof(b)*: 1, default: 0),                  \
                   M_LIB_NOT_SAME_TYPE,                                        \

--- a/m-core.h
+++ b/m-core.h
@@ -4291,7 +4291,7 @@ M_INLINE size_t m_core_cstr_hash(const char str[])
                   M_LIB_NOT_SAME_TYPE,                                        \
                   "The variable " M_AS_STR(a) " and " M_AS_STR(b)             \
                   " are not of same type.")
-#elif defined(m_typeof)
+#elif defined(m_typeof) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define M_CHECK_SAME(a, b)                                                    \
   M_STATIC_ASSERT(_Generic(&a, m_typeof(b)*: 1, default: 0),                  \
                   M_LIB_NOT_SAME_TYPE,                                        \

--- a/m-core.h
+++ b/m-core.h
@@ -4293,7 +4293,7 @@ M_INLINE size_t m_core_cstr_hash(const char str[])
                   " are not of same type.")
 #elif defined(m_typeof) && defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define M_CHECK_SAME(a, b)                                                    \
-  M_STATIC_ASSERT(_Generic(&a, m_typeof(b)*: 1, default: 0),                  \
+  M_STATIC_ASSERT(_Generic((0,a), m_typeof((0,b)): 1, default: 0),            \
                   M_LIB_NOT_SAME_TYPE,                                        \
                   "The variable " M_AS_STR(a) " and " M_AS_STR(b)             \
                   " are not of same type.")


### PR DESCRIPTION
With support of 
* GCC
* CLANG
* TCC
* MSVC
* slimcc

kefir and antcc are not supported as they don't seem to define an env variable identifying the compiler.